### PR TITLE
Implement unzip cpk logic, use minilzo for compress/decompress

### DIFF
--- a/tools/Pal3CpkTool/Pal3CpkTool/CPK.cpp
+++ b/tools/Pal3CpkTool/Pal3CpkTool/CPK.cpp
@@ -2,12 +2,12 @@
 
 #include <cassert>
 #include <io.h>
+#include "minilzo/minilzo.h"
 
 
 static bool g_bCrcTableInitialized = false;
 DWORD *CPK::CrcTable[256] = { 0 };
-static int encryptTable[256] = { 0 };
-
+void* CPK::lzo_wrkmem = nullptr;
 
 
 
@@ -17,8 +17,11 @@ CPK::CPK()
     this->dwOpenMode = ECPKMode_Mapped;
     dwAllocationGranularity = GetAllocationGranularity();
 
-    if (!g_bCrcTableInitialized)
+    if (!g_bCrcTableInitialized) {
         InitCrcTable();
+        lzo_wrkmem = new char[LZO1X_MEM_COMPRESS];
+        memset(lzo_wrkmem, 0, LZO1X_MEM_COMPRESS);
+    }
 
     gbVFile **ppVFile = vFiles;
     int iCount = 8;
@@ -338,7 +341,7 @@ bool CPK::buildDirectoryTree(CPKDirectoryEntry& entry)
     //set up root directory info
     entry.vCRC = 0;
     entry.vParentCRC = 0;
-    entry.iAttrib = 0;
+    entry.iAttrib = CpkFileAttrib_None;
     strcpy_s(entry.lpszName, sizeof(entry.lpszName), fileName);
     //用来记录所有已经处理过的节点，避免重复处理
     std::map<DWORD, CPKDirectoryEntry*> handledEntries;
@@ -359,6 +362,7 @@ bool CPK::buildDirectoryTree(CPKDirectoryEntry& entry)
             assert(false);
         }
     }
+    return true;
 }
 
 bool CPK::buildParent(CpkFileEntry& currFileEntry, std::map<DWORD, CPKDirectoryEntry*>& handledEntries)
@@ -497,7 +501,7 @@ bool CPK::Unload()
     return true;
 }
 
-char* CPK::ReadLine(char *lpBuffer, int ReadSize, struct CPKFile *pCpkFile)
+char* CPK::ReadLine(char *lpBuffer, int ReadSize, CPKFile *pCpkFile)
 {
     if (ReadSize - 1 <= 0)
         return 0;
@@ -552,112 +556,29 @@ CPKFile* CPK::Open(const char *lpString2)
 {
     if (!isLoaded)
         return nullptr;
-    if ((signed int)dwVFileOpenedCount >= ARRAYSIZE(vFiles) - 1) {
-        //showMsgBox(0x10u, aErrorCeCannotO_0, aDProjectGbengi, 361);
-        return nullptr;
-    }
     int currIndex = GetTableIndex(lpString2);
     if (currIndex == -1)
         return nullptr;
-    CpkFileEntry* pFileEntry = &entries[currIndex];
-    DWORD alignedOffset = pFileEntry->Offset;
-    DWORD dwFileOffsetLow = pFileEntry->Offset;
-    if (dwOpenMode == ECPKMode_Mapped) {
-        alignedOffset -= alignedOffset % dwAllocationGranularity;
-        dwFileOffsetLow = alignedOffset;
-    }
-    int unalignedLen = pFileEntry->Offset - alignedOffset;
-    size_t mappedSize = unalignedLen + pFileEntry->CompressedSize;
-    int iIndex = 0;
-    for (; iIndex < ARRAYSIZE(vFiles); iIndex++) {
-        if (!vFiles[iIndex]->cpkFile.bOpened)
-            break;
-    }
-    if (iIndex >= 8) {
-        return 0;
-    }
-    gbVFile* pVFile = vFiles[iIndex];
-    if (!pVFile) {
-        return 0;
-    }
-    CPKFile* pCpkFile = &pVFile->cpkFile;
 
-    //open the cpk file and decompress data
-    pCpkFile->bOpened = 1;
+    gbVFile* pVFile = OpenTableIndex(currIndex);
+    if (!pVFile)
+        return nullptr;
     strcpy_s(pVFile->fileName, sizeof(pVFile->fileName), lpString2);
-    pCpkFile->lpMapFileBase = 0;
-    if (dwOpenMode == ECPKMode_Mapped) {
-        void* lpMapped = MapViewOfFile(fileMappingHandle, 4u, 0, dwFileOffsetLow, mappedSize);// 把文件的一部分map过去
-        if (!lpMapped) {
-            DWORD dwErr = GetLastError();
-            OutputDebugStringA("error");
-        }
-        pCpkFile->lpMapFileBase = lpMapped;
-        if (!lpMapped) {
-            pCpkFile->bOpened = 0;
-            return nullptr;
-        }
-    }
-    pCpkFile->vCRC = pFileEntry->vCRC;
-    pCpkFile->fileIndex = currIndex;
-    pCpkFile->vParentCRC = pFileEntry->vParentCRC;
-    pCpkFile->pRecordEntry = pFileEntry;// 记录entry结构指针
-    pCpkFile->pSrc = &(((char *)pCpkFile->lpMapFileBase)[unalignedLen]);
+    return &pVFile->cpkFile;
+}
 
-    pCpkFile->isCompressed = (pFileEntry->Attrib & 0xFFFF0000) != 0x10000;
-    DWORD originalSize = pFileEntry->OriginalSize;
-    pCpkFile->srcOffset = unalignedLen;
-    pCpkFile->originalSize = originalSize;
-    pCpkFile->fileOffset = 0;
-    if (pCpkFile->isCompressed && originalSize) {
-        if (dwOpenMode != ECPKMode_Mapped) {
-            pCpkFile->bOpened = 0;
-            return nullptr;
-        }
-        /*if (!(byte_10167011 & 1)) {
-            byte_10167011 |= 1u;
-            sub_1002DCF0(bufferHandle, 2, 1);
-            atexit(unknown_libname_2);
-        }*/
-        void* pDest = new char[pCpkFile->originalSize];
-        //v27 = cpkAllocBuffer((HANDLE *)bufferHandle, pCpkFile->compressedSize);
-        pCpkFile->pDest = pDest;
-        if (!pDest) {
-            //showMsgBox(0x10u, aErrorCeCannotA, aDProjectGbengi, 464);
-            UnmapViewOfFile(pCpkFile->lpMapFileBase);
-            pCpkFile->bOpened = 0;
-            return 0;
-        }
-        CpkZipUnzipParam param; // [esp+2Ch] [ebp-168h]
-        param.flag = pFileEntry->Attrib >> 0x10;
-        param.srcSizeUnused = pFileEntry->CompressedSize;
-        param.srcSize = pFileEntry->CompressedSize;
-        param.bCompress = 0;
-        param.bResult = 0;
-        param.destSize = pFileEntry->OriginalSize;
-        param.destResultSize = pFileEntry->OriginalSize;
-        param.src = pCpkFile->pSrc;
-        param.dest = pCpkFile->pDest;
-        executeZipUnZip(&param);
-        if (!param.bResult) {
-            //showMsgBox(0x10u, aErrorCeCannotD, aDProjectGbengi, 486);
-            //cpkUnmapViewOfFile(pVFile->lpMapFileBase);
-            /*if (!(byte_10167011 & 1)) {
-                byte_10167011 |= 1u;
-                sub_1002DCF0(bufferHandle, 2, 1);
-                atexit(unknown_libname_2);
-            }*/
-            //sub_1002E090((HANDLE *)bufferHandle, pCpkFile->pDest, pCpkFile->originalSize);
-            delete[] pCpkFile->pDest;
-            pCpkFile->bOpened = 0;
-            return 0;
-        }
-    } else {
-        pCpkFile->pDest = pCpkFile->pSrc;
-    }
-    if (dwOpenMode != ECPKMode_Mapped)
-        SetFilePointer(fileHandle, pCpkFile->pRecordEntry->Offset, 0, 0);
-    ++dwVFileOpenedCount;
+CPKFile * CPK::Open(DWORD vCRC, const char* saveFileName)
+{
+    if (!isLoaded)
+        return nullptr;
+    int currIndex = GetTableIndexFromCRC(vCRC);
+    if (currIndex == -1)
+        return nullptr;
+
+    gbVFile* pVFile = OpenTableIndex(currIndex);
+    if (!pVFile)
+        return nullptr;
+    strcpy_s(pVFile->fileName, sizeof(pVFile->fileName), saveFileName);
     return &pVFile->cpkFile;
 }
 
@@ -715,23 +636,24 @@ int CPK::executeZipUnZip(CpkZipUnzipParam *param)
         if (param->flag != 2)
             return result;
         if (param->bCompress) {
-            result = processCompress(
-                (unsigned __int8 *)param->src,
+            result = lzo1x_1_compress((unsigned __int8 *)param->src,
                 param->srcSize,
                 (BYTE*)param->dest,
-                &param->destResultSize,
-                (int)&encryptTable);
+                (unsigned int*)&param->destResultSize,
+                (void*)lzo_wrkmem);
             if (result) {
                 param->bResult = 0;
                 return -1;
             }
         } else {
-            result = processDeCompress(
+            result = lzo1x_decompress(
                 (unsigned __int8 *)param->src,
                 param->srcSize,
                 (BYTE *)param->dest,
-                &param->destResultSize);
-            if (result) {
+                (unsigned int*)&param->destResultSize,
+                nullptr
+            );
+            if (result != LZO_E_OK) {
                 param->bResult = 0;
                 return -1;
             }
@@ -741,474 +663,114 @@ int CPK::executeZipUnZip(CpkZipUnzipParam *param)
     return result;
 }
 
-int CPK::processCompress(unsigned __int8 *src, unsigned int decompressSize, unsigned char *dest, DWORD *bResult, int encryptTable)
+gbVFile* CPK::OpenTableIndex(int iFileTableIndex)
 {
-    unsigned int v5; // ecx
-    unsigned char *v6; // edi
-    unsigned char *v7; // esi
-    unsigned int v8; // ebx
-    unsigned char *v9; // esi
-    unsigned __int8 *v10; // ebp
-    unsigned __int8 v11; // dl
-    unsigned int v12; // eax
-    unsigned int v13; // ebx
-    unsigned __int8 **v14; // edi
-    unsigned int v15; // ecx
-    unsigned int v16; // eax
-    unsigned int v17; // eax
-    unsigned int v18; // eax
-    char v19; // dl
-    unsigned int v20; // edx
-    unsigned int v21; // eax
-    unsigned __int8 v22; // al
-    char v23; // dl
-    char v24; // al
-    char v25; // dl
-    char v26; // al
-    char v27; // dl
-    unsigned char *i; // ebx
-    unsigned int v29; // ebx
-    int v30; // eax
-    unsigned int v31; // ecx
-    unsigned char *v32; // esi
-    unsigned char v33; // ebx
-    unsigned int v34; // eax
-    unsigned char *v35; // esi
-    unsigned int v36; // eax
-    char v37; // al
-    unsigned int v38; // ecx
-    unsigned char *v39; // esi
-    unsigned int v40; // ecx
-    unsigned __int8 *v41; // ebx
-    int v42; // esi
-    unsigned __int8 *v43; // eax
-    char v44; // cl
-    unsigned int v45; // edx
-    unsigned int v46; // ecx
-    unsigned char *v47; // edi
-    unsigned char *v48; // esi
-    unsigned int v50; // [esp+10h] [ebp-18h]
-    int v51; // [esp+10h] [ebp-18h]
-    unsigned __int8 *v52; // [esp+14h] [ebp-14h]
-    char v53; // [esp+18h] [ebp-10h]
-    unsigned __int8 *v54; // [esp+1Ch] [ebp-Ch]
-    int srca; // [esp+2Ch] [ebp+4h]
-    unsigned __int8 *encryptTablea; // [esp+3Ch] [ebp+14h]
+    if ((signed int)dwVFileOpenedCount >= ARRAYSIZE(vFiles) - 1) {
+        //showMsgBox(0x10u, aErrorCeCannotO_0, aDProjectGbengi, 361);
+        return nullptr;
+    }
 
-    v5 = decompressSize;
-    v6 = dest;
-    v7 = dest;
-    if (decompressSize <= 0xD) {
-        v8 = decompressSize;
-        goto LABEL_61;
+    CpkFileEntry* pFileEntry = &entries[iFileTableIndex];
+    DWORD alignedOffset = pFileEntry->Offset;
+    DWORD dwFileOffsetLow = pFileEntry->Offset;
+    if (dwOpenMode == ECPKMode_Mapped) {
+        alignedOffset -= alignedOffset % dwAllocationGranularity;
+        dwFileOffsetLow = alignedOffset;
     }
-    v9 = dest;
-    v52 = src;
-    v10 = src + 4;
-    v54 = &src[decompressSize];
-    do {
-        while (1) {
-            v11 = v10[3];
-            v12 = (33 * (*v10 ^ 32 * (v10[1] ^ 32 * (v10[2] ^ ((unsigned int)v10[3] << 6)))) >> 5) & 0x3FFF;
-            v13 = *(DWORD *)(encryptTable + 4 * v12);
-            v14 = (unsigned __int8 **)(encryptTable + 4 * v12);
-            if (v13 < (unsigned int)src)
-                goto LABEL_58;
-            v15 = (unsigned int)&v10[-(int)v13];
-            v50 = (unsigned int)&v10[-(int)v13];
-            if (v10 == (unsigned __int8 *)v13 || v15 > 0xBFFF)
-                goto LABEL_58;
-            if (v15 > 0x800 && *(unsigned char *)(v13 + 3) != v11)
-                break;
-        LABEL_15:
-            if (*(unsigned short *)v13 != *(unsigned short *)v10 || *(unsigned char *)(v13 + 2) != v10[2])
-                goto LABEL_58;
-            *v14 = v10;
-            v18 = v10 - v52;
-            if (v10 - v52 > 0) {
-                if (v18 > 3) {
-                    if (v18 > 0x12) {
-                        *v9++ = 0;
-                        v53 = v18 - 18;
-                        if (v18 - 18 > 0xFF) {
-                            v20 = (v18 - 19) / 0xFF;
-                            memset(v9, 0, v20);
-                            v21 = (v18 - 19) / 0xFF;
-                            v9 += v20;
-                            do {
-                                --v21;
-                                ++v53;
-                            } while (v21);
-                            v15 = v50;
-                            v18 = v10 - v52;
-                        }
-                        v19 = v53;
-                    } else {
-                        v19 = v18 - 3;
-                    }
-                    *v9++ = v19;
-                } else {
-                    *(v9 - 2) |= v18;
-                }
-                do {
-                    ++v9;
-                    --v18;
-                    *(v9 - 1) = *v52++;
-                } while (v18);
-            }
-            v22 = v10[3];
-            v10 += 4;
-            if (*(unsigned char *)(v13 + 3) == v22) {
-                v23 = *v10++;
-                if (*(unsigned char *)(v13 + 4) == v23) {
-                    v24 = *v10++;
-                    if (*(unsigned char *)(v13 + 5) == v24) {
-                        v25 = *v10++;
-                        if (*(unsigned char *)(v13 + 6) == v25) {
-                            v26 = *v10++;
-                            if (*(unsigned char *)(v13 + 7) == v26) {
-                                v27 = *v10++;
-                                if (*(unsigned char *)(v13 + 8) == v27) {
-                                    for (i = (unsigned char *)(v13 + 9); v10 < v54; ++v10) {
-                                        if (*i != *v10)
-                                            break;
-                                        ++i;
-                                    }
-                                    v29 = v10 - v52;
-                                    if (v50 > 0x4000) {
-                                        v34 = v50 - 0x4000;
-                                        v51 = v50 - 0x4000;
-                                        if (v29 <= 9) {
-                                            v31 = v51;
-                                            *v9 = (v29 - 2) | (v34 >> 11) & 8 | 0x10;
-                                            v32 = v9 + 1;
-                                            goto LABEL_55;
-                                        }
-                                        v33 = v29 - 9;
-                                        *v9 = (v34 >> 11) & 8 | 0x10;
-                                    } else {
-                                        v30 = v50 - 1;
-                                        v51 = v50 - 1;
-                                        if (v29 <= 0x21) {
-                                            v31 = v30;
-                                            *v9 = (v29 - 2) | 0x20;
-                                            v32 = v9 + 1;
-                                        LABEL_55:
-                                            *v32 = 4 * v31;
-                                            v39 = v32 + 1;
-                                            v40 = v31 >> 6;
-                                            goto LABEL_56;
-                                        }
-                                        v33 = v29 - 33;
-                                        *v9 = 32;
-                                    }
-                                    v35 = v9 + 1;
-                                    if (v33 > 0xFF) {
-                                        memset(v35, 0, 4 * ((v33 - 1) / 0x3FC) + ((v33 - 1) / 0xFF & 3));
-                                        v36 = (v33 - 1) / 0xFF;
-                                        v35 += v36;
-                                        do {
-                                            v33 = v33 + 1;
-                                            --v36;
-                                        } while (v36);
-                                    }
-                                    v31 = v51;
-                                    *v35 = v33;
-                                    v32 = v35 + 1;
-                                    goto LABEL_55;
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-            v37 = (unsigned char)--v10 - (unsigned char)v52;
-            if (v15 > 0x800) {
-                if (v15 > 0x4000) {
-                    v31 = v15 - 0x4000;
-                    *v9 = (v37 - 2) | (v31 >> 11) & 8 | 0x10;
-                } else {
-                    v31 = v15 - 1;
-                    *v9 = (v37 - 2) | 0x20;
-                }
-                v32 = v9 + 1;
-                goto LABEL_55;
-            }
-            v38 = v15 - 1;
-            *v9 = 4 * (v38 & 7) | 32 * (v37 + 7);
-            v39 = v9 + 1;
-            v40 = v38 >> 3;
-        LABEL_56:
-            v41 = &src[decompressSize];
-            *v39 = v40;
-            v9 = v39 + 1;
-            v52 = v10;
-            if (v10 >= v54 - 13)
-                goto LABEL_60;
-        }
-        v16 = (33 * (*v10 ^ 32 * (v10[1] ^ 32 * (v10[2] ^ ((unsigned int)v10[3] << 6)))) >> 5) & 0x7FF ^ 0x201F;
-        v13 = *(DWORD *)(encryptTable + 4 * v16);
-        v14 = (unsigned __int8 **)(encryptTable + 4 * v16);
-        if (v13 >= (unsigned int)src) {
-            v17 = (unsigned int)&v10[-(int)v13];
-            v50 = (unsigned int)&v10[-(int)v13];
-            if (v10 != (unsigned __int8 *)v13 && v17 <= 0xBFFF && (v17 <= 0x800 || *(unsigned char *)(v13 + 3) == v11)) {
-                v15 = (unsigned int)&v10[-(int)v13];
-                goto LABEL_15;
-            }
-        }
-    LABEL_58:
-        *v14 = v10++;
-    } while (v10 < v54 - 13);
-    v41 = &src[decompressSize];
-LABEL_60:
-    v42 = v9 - dest;
-    *bResult = v42;
-    v8 = v41 - v52;
-    v5 = decompressSize;
-    v7 = &dest[v42];
-    v6 = dest;
-LABEL_61:
-    if (v8) {
-        v43 = &src[v5 - v8];
-        encryptTablea = &src[v5 - v8];
-        if (v7 == v6 && v8 <= 0xEE) {
-            v44 = v8 + 17;
-            goto LABEL_73;
-        }
-        if (v8 > 3) {
-            if (v8 > 0x12) {
-                v44 = v8 - 18;
-                *v7++ = 0;
-                srca = v8 - 18;
-                if (v8 - 18 > 0xFF) {
-                    v45 = (v8 - 19) / 0xFF;
-                    v46 = (v8 - 19) / 0x3FC;
-                    memset(v7, 0, 4 * v46);
-                    v47 = &v7[4 * v46];
-                    v7 += v45;
-                    memset(v47, 0, v45 & 3);
-                    do {
-                        v44 = srca + 1;
-                        --v45;
-                        srca -= 255;
-                    } while (v45);
-                    v43 = encryptTablea;
-                    v6 = dest;
-                }
-            LABEL_73:
-                *v7 = v44;
-            } else {
-                *v7 = v8 - 3;
-            }
-            ++v7;
-        } else {
-            *(v7 - 2) |= v8;
-        }
-        do {
-            *v7++ = *v43++;
-            --v8;
-        } while (v8);
-    }
-    *v7 = 17;
-    v48 = v7 + 1;
-    *v48++ = 0;
-    *v48 = 0;
-    *bResult = v48 - v6 + 1;
-    return 0;
-}
-
-int CPK::processDeCompress(unsigned __int8 *src, int decompressSize, unsigned char *dest, DWORD *resultSize)
-{
-    unsigned __int8 *v4; // esi
-    unsigned __int8 *v5; // ebp
-    unsigned char *v6; // eax
-    unsigned int v7; // ecx
-    unsigned int v8; // ecx
-    unsigned __int8 *v9; // esi
-    unsigned __int8 v10; // dl
-    int v11; // edx
-    int v12; // edx
-    unsigned int v13; // ecx
-    int v14; // edx
-    unsigned char *v15; // edx
-    unsigned char *v16; // eax
-    unsigned char *v17; // edi
-    unsigned int v18; // ecx
-    unsigned char *v19; // eax
-    unsigned char *v20; // edi
-    unsigned __int8 v21; // dl
-    int v22; // edx
-    int v23; // edi
-    unsigned __int8 v24; // dl
-    int v25; // edx
-    unsigned __int16 v26; // dx
-    unsigned int v27; // edi
-    int v28; // edx
-    unsigned char *v29; // edi
-    unsigned int v30; // ecx
-    char v32; // eax
-
-    v4 = src;
-    *resultSize = 0;
-    v5 = &src[decompressSize];
-    v6 = dest;
-    if (*src > 0x11u) {
-        v7 = *src - 17;
-        v4 = src + 1;
-        if (v7 < 4)
-            goto LABEL_21;
-        do {
-            *v6++ = *v4++;
-            --v7;
-        } while (v7);
-        goto LABEL_17;
-    }
-LABEL_5:
-    v8 = *v4;
-    v9 = v4 + 1;
-    if (v8 < 0x10) {
-        if (!v8) {
-            if (!*v9) {
-                do {
-                    v10 = v9[1];
-                    v8 += 255;
-                    ++v9;
-                } while (!v10);
-            }
-            v11 = *v9++;
-            v8 += v11 + 15;
-        }
-        v12 = *(DWORD *)v9;
-        v4 = v9 + 4;
-        *(DWORD *)v6 = v12;
-        v6 += 4;
-        v13 = v8 - 1;
-        if (v13) {
-            if (v13 < 4) {
-                do {
-                    *v6++ = *v4++;
-                    --v13;
-                } while (v13);
-            } else {
-                do {
-                    v13 -= 4;
-                    *(DWORD *)v6 = *(DWORD *)v4;
-                    v6 += 4;
-                    v4 += 4;
-                } while (v13 >= 4);
-                for (; v13; --v13)
-                    *v6++ = *v4++;
-            }
-        }
-    LABEL_17:
-        v8 = *v4;
-        v9 = v4 + 1;
-        if (v8 < 0x10) {
-            v14 = (int)&v6[-(int)(v8 >> 2) + -4 * *v9];
-            v4 = v9 + 1;
-            *v6++ = *(unsigned char *)(v14 - 2049);
-            v15 = (unsigned char *)(v14 - 2049 + 1);
-        LABEL_19:
-            *v6 = *v15;
-            v16 = v6 + 1;
-            *v16 = v15[1];
-            v6 = v16 + 1;
-            goto LABEL_20;
-        }
-    }
-    while (1) {
-        if (v8 >= 0x40) {
-            v17 = &v6[-(int)((v8 >> 2) & 7) - 1 + -8 * *v9];
-            v4 = v9 + 1;
-            v18 = (v8 >> 5) - 1;
-        LABEL_25:
-            *v6 = *v17;
-            v19 = v6 + 1;
-            *v19 = v17[1];
-            v6 = v19 + 1;
-            v20 = v17 + 2;
-            do {
-                *v6++ = *v20++;
-                --v18;
-            } while (v18);
-            goto LABEL_20;
-        }
-        if (v8 < 0x20)
+    int unalignedLen = pFileEntry->Offset - alignedOffset;
+    size_t mappedSize = unalignedLen + pFileEntry->CompressedSize;
+    int iIndex = 0;
+    for (; iIndex < ARRAYSIZE(vFiles); iIndex++) {
+        if (!vFiles[iIndex]->cpkFile.bOpened)
             break;
-        v18 = v8 & 0x1F;
-        if (!v18) {
-            if (!*v9) {
-                do {
-                    v21 = v9[1];
-                    v18 += 255;
-                    ++v9;
-                } while (!v21);
-            }
-            v22 = *v9++;
-            v18 += v22 + 31;
-        }
-        v17 = &v6[-(int)((unsigned int)*(unsigned __int16 *)v9 >> 2) - 1];
-        v4 = v9 + 2;
-    LABEL_41:
-        if (v18 < 6 || v6 - v17 < 4)
-            goto LABEL_25;
-        v28 = *(DWORD *)v17;
-        v29 = v17 + 4;
-        *(DWORD *)v6 = v28;
-        v6 += 4;
-        v30 = v18 - 2;
-        do {
-            v30 -= 4;
-            *(DWORD *)v6 = *(DWORD *)v29;
-            v6 += 4;
-            v29 += 4;
-        } while (v30 >= 4);
-        for (; v30; --v30)
-            *v6++ = *v29++;
-    LABEL_20:
-        v7 = *(v4 - 2) & 3;
-        if (!(*(v4 - 2) & 3))
-            goto LABEL_5;
-        do {
-        LABEL_21:
-            *v6++ = *v4++;
-            --v7;
-        } while (v7);
-        v8 = *v4;
-        v9 = v4 + 1;
     }
-    if (v8 < 0x10) {
-        v15 = &v6[-(int)(v8 >> 2) - 1 + -4 * *v9];
-        v4 = v9 + 1;
-        goto LABEL_19;
-    }
-    v23 = (int)&v6[-2048 * (v8 & 8)];
-    v18 = v8 & 7;
-    if (!v18) {
-        if (!*v9) {
-            do {
-                v24 = v9[1];
-                v18 += 255;
-                ++v9;
-            } while (!v24);
-        }
-        v25 = *v9++;
-        v18 += v25 + 7;
-    }
-    v26 = *(unsigned short *)v9;
-    v4 = v9 + 2;
-    v27 = v23 - ((unsigned int)v26 >> 2);
-    if ((unsigned char *)v27 != v6) {
-        v17 = (unsigned char *)(v27 - 0x4000);
-        goto LABEL_41;
-    }
-    *resultSize = v6 - dest;
-    if (v4 == v5)
+    if (iIndex >= 8) {
         return 0;
-    v32 = -(v4 < v5);
-    v32 = v32 & 0xFC;
-    return v32 - 4;
+    }
+    gbVFile* pVFile = vFiles[iIndex];
+    if (!pVFile) {
+        return 0;
+    }
+    CPKFile* pCpkFile = &pVFile->cpkFile;
+
+    //open the cpk file and decompress data
+    pCpkFile->bOpened = 1;
+    //strcpy_s(pVFile->fileName, sizeof(pVFile->fileName), lpString2);
+    pCpkFile->lpMapFileBase = 0;
+    if (dwOpenMode == ECPKMode_Mapped) {
+        void* lpMapped = MapViewOfFile(fileMappingHandle, 4u, 0, dwFileOffsetLow, mappedSize);// 把文件的一部分map过去
+        if (!lpMapped) {
+            DWORD dwErr = GetLastError();
+            OutputDebugStringA("error");
+        }
+        pCpkFile->lpMapFileBase = lpMapped;
+        if (!lpMapped) {
+            pCpkFile->bOpened = 0;
+            return nullptr;
+        }
+    }
+    pCpkFile->vCRC = pFileEntry->vCRC;
+    pCpkFile->fileIndex = iFileTableIndex;
+    pCpkFile->vParentCRC = pFileEntry->vParentCRC;
+    pCpkFile->pRecordEntry = pFileEntry;// 记录entry结构指针
+    pCpkFile->pSrc = &(((char *)pCpkFile->lpMapFileBase)[unalignedLen]);
+
+    pCpkFile->isCompressed = (pFileEntry->Attrib & 0xFFFF0000) != 0x10000;
+    DWORD originalSize = pFileEntry->OriginalSize;
+    pCpkFile->srcOffset = unalignedLen;
+    pCpkFile->originalSize = originalSize;
+    pCpkFile->fileOffset = 0;
+    if (pCpkFile->isCompressed && originalSize) {
+        if (dwOpenMode != ECPKMode_Mapped) {
+            pCpkFile->bOpened = 0;
+            return nullptr;
+        }
+        /*if (!(byte_10167011 & 1)) {
+            byte_10167011 |= 1u;
+            sub_1002DCF0(bufferHandle, 2, 1);
+            atexit(unknown_libname_2);
+        }*/
+        void* pDest = new char[pCpkFile->originalSize];
+        //v27 = cpkAllocBuffer((HANDLE *)bufferHandle, pCpkFile->compressedSize);
+        pCpkFile->pDest = pDest;
+        if (!pDest) {
+            //showMsgBox(0x10u, aErrorCeCannotA, aDProjectGbengi, 464);
+            UnmapViewOfFile(pCpkFile->lpMapFileBase);
+            pCpkFile->bOpened = 0;
+            return nullptr;
+        }
+        CpkZipUnzipParam param; // [esp+2Ch] [ebp-168h]
+        param.flag = pFileEntry->Attrib >> 0x10;
+        param.srcSizeUnused = pFileEntry->CompressedSize;
+        param.srcSize = pFileEntry->CompressedSize;
+        param.bCompress = 0;
+        param.bResult = 0;
+        param.destSize = pFileEntry->OriginalSize;
+        param.destResultSize = pFileEntry->OriginalSize;
+        param.src = pCpkFile->pSrc;
+        param.dest = pCpkFile->pDest;
+        executeZipUnZip(&param);
+        if (!param.bResult) {
+            //showMsgBox(0x10u, aErrorCeCannotD, aDProjectGbengi, 486);
+            //cpkUnmapViewOfFile(pVFile->lpMapFileBase);
+            /*if (!(byte_10167011 & 1)) {
+                byte_10167011 |= 1u;
+                sub_1002DCF0(bufferHandle, 2, 1);
+                atexit(unknown_libname_2);
+            }*/
+            //sub_1002E090((HANDLE *)bufferHandle, pCpkFile->pDest, pCpkFile->originalSize);
+            delete[] pCpkFile->pDest;
+            pCpkFile->bOpened = 0;
+            return nullptr;
+        }
+    } else {
+        pCpkFile->pDest = pCpkFile->pSrc;
+    }
+    if (dwOpenMode != ECPKMode_Mapped)
+        SetFilePointer(fileHandle, pCpkFile->pRecordEntry->Offset, 0, 0);
+    ++dwVFileOpenedCount;
+    //return &pVFile->cpkFile;
+    return pVFile;
 }
 
 bool CPK::GetFileSize(DWORD &CompressedSize, DWORD &OriginalSize, DWORD targetCRC)

--- a/tools/Pal3CpkTool/Pal3CpkTool/CPK.h
+++ b/tools/Pal3CpkTool/Pal3CpkTool/CPK.h
@@ -17,27 +17,17 @@ enum CpkFileAttrib {
 
 
 struct CpkFileEntry {
-    unsigned int vCRC;           //据我猜测应该是根据文件名Hash出的一个数值，若干个Index结构在CPK文件中就是按这个数值升序排列的。
-                                //这样的好处是只要计算出要访问文件的CRC，就可以利用二分查找在对数时间内定位该文件的Index，进而读取数据。
-
-    unsigned int Attrib;        //0002,0001都是文件, 区别忘了貌似是一个是压缩一个是未压缩. 而0011是已删除的文件, 0003是目录. 或许也会有0013表示已删除的目录
-
-    unsigned int vParentCRC;     //一个CRC值，等于它的父目录的CRC。CPK文件支持子目录，当你定位好一个文件的index后，通过这个指针反复向上层遍历，
-                            //就可以取得它的完整的存储路径。在根目录下的文件的Index中此值为0。
-
-    unsigned int Offset;        //压缩后的数据在CPK中的偏移量。
-
-    unsigned int CompressedSize;//压缩后数据的大小。对于目录，这个值为0。
-
-    unsigned int OriginalSize;  //原始文件的大小，方便你解压时开缓冲区。
-
-    unsigned int InfoRecordSize;/*奇怪的参数。对于每一个Index所代表的文件，压缩后的数据在CPK中从index.Offset起开始存储，占用index.CompressedSize的空间，
-                              接下来就是一个大小为InfoRecordSize的奇怪记录，我只知道这个记录的一开头就是文件名，以#0结束，其他的都不清楚，有兴趣的可以研究一下。
-                              需要注意的是，只要InfoRecordSize为0，或这个Index不是目录，但CompressedSize为0，这个Index就毫无疑义，不需处理。
-                              我因为多次运行升级程序（为了调试它来研究CPK格式），文件中已有好多这样的无效Index了。*/
+    unsigned int vCRC;                  //0x00  当前节点CRC
+    CpkFileAttrib Attrib;               //0x04  文件属性信息
+    DWORD vParentCRC;                   //0x08  父节点CRC，根节点为0
+    unsigned int Offset;                //0x0C  压缩后的数据在CPK中的偏移量。
+    unsigned int CompressedSize;        //0x10  压缩后数据的大小。对于目录，这个值为0。
+    unsigned int OriginalSize;          //0x14  原始文件的大小，方便你解压时开缓冲区。
+    unsigned int InfoRecordSize;        //0x18  文件名信息偏移 信息紧跟着压缩数据之后，所以从Offset + CompressedSize读取InfoRecordSize，最开头就是文件名
 };
 
-struct CPKFile {
+class CPKFile {
+public:
     bool bOpened;                   //0x110     是否打开
     DWORD vCRC;                     //0x114     本节点CRC
     DWORD vParentCRC;               //0x118     父节点CRC
@@ -58,30 +48,30 @@ struct gbVFile {
     DWORD unknown2;                 //0x4
     DWORD unknown3;                 //0x8
     char fileName[MAX_PATH];        //0xC       文件名
-    CPKFile cpkFile;                //0x110
+    CPKFile cpkFile;                //0x110     文件信息结构
 };
 
 
 struct CpkZipUnzipParam {
-    int flag;
-    bool bCompress;
-    void* src;
-    void* dest;
-    DWORD srcSizeUnused;
-    DWORD destSize;
-    DWORD srcSize;
-    DWORD destResultSize;
-    bool bResult;
+    int flag;                       //0x00  一般为2，从CpkFileEntry::Attrib的HIWORD复制
+    bool bCompress;                 //0x04  是否启用压缩
+    void* src;                      //0x08  文件源数据指针
+    void* dest;                     //0x0C  文件目标数据指针
+    DWORD srcSizeUnused;            //0x10  暂时未发现有使用
+    DWORD destSize;                 //0x14  目标数据大小
+    DWORD srcSize;                  //0x18  源数据大小
+    DWORD destResultSize;           //0x1C  实际得到的数据大小
+    bool bResult;                   //0x20  操作是否成功
 };
 
 //0x80
 struct CpkHeader {
     unsigned int signature; //0x0
-    DWORD dwCheckFlag;      //0x4  合法的CPK文件此处值必须为1
+    DWORD dwCheckFlag;      //0x4   合法的CPK文件此处值必须为1
     DWORD unknown[0x2];     //0x08
-    DWORD entryCapacity;    //0x10
+    DWORD entryCapacity;    //0x10  CpkFileEntry数组容量
     DWORD unknown2[0x3];    //0x14
-    unsigned int dwCount;   //0x20
+    unsigned int dwCount;   //0x20  CpkFileEntry数组数量
     char unknown3[0x5C];    //0x24
 };
 
@@ -165,16 +155,16 @@ private:
 
 
 private:
-    DWORD dwAllocationGranularity;                  //0x0
-    ECPKMode dwOpenMode;                            //0x4
-    CpkHeader cpkHeader;                            //0x8
-    CpkFileEntry entries[0x8000];                   //0x88
-    gbVFile* vFiles[0x8];                           //0xE0088
-    bool isLoaded;                                  //0xE00A8
-    HANDLE fileHandle;                              //0xE0090
-    HANDLE fileMappingHandle;                       //0xE0094
-    char fileName[MAX_PATH];                        //0xE0098
-    DWORD dwVFileOpened;                            //0xE009C
+    DWORD dwAllocationGranularity;                  //0x0           块对齐长度，做文件映射时需要对齐到该长度，否则映射失败
+    ECPKMode dwOpenMode;                            //0x4           打开模式 当前为ECPKMode_Mapped
+    CpkHeader cpkHeader;                            //0x8           文件头信息
+    CpkFileEntry entries[0x8000];                   //0x88          文件节点信息数组，通过哈希存储
+    gbVFile* vFiles[0x8];                           //0xE0088       文件数组
+    bool isLoaded;                                  //0xE00A8       是否已加载
+    HANDLE fileHandle;                              //0xE0090       文件句柄
+    HANDLE fileMappingHandle;                       //0xE0094       文件映射句柄
+    char fileName[MAX_PATH];                        //0xE0098       CPK文件名
+    DWORD dwVFileOpenedCount;                       //0xE009C       当前打开的gbVFile文件数量
 
 private:
     static DWORD *CrcTable[256];

--- a/tools/Pal3CpkTool/Pal3CpkTool/CPK.h
+++ b/tools/Pal3CpkTool/Pal3CpkTool/CPK.h
@@ -5,50 +5,50 @@
 #include <map>
 
 
-enum CpkFileAttrib {
-    CpkFileAttrib_None = 0x0,
-    CpkFileAttrib_IsFile = 0x1,         //是否是合法文件？
-    CpkFileAttrib_IsDir = 0x2,          //是否是目录
-    CpkFileAttrib_Unknown2 = 0x4,
-    CpkFileAttrib_Unknown3 = 0x8,
-    CpkFileAttrib_IsDeleted = 0x10,     //是否已删除
+enum CPKTableFlag {
+    CPKTableFlag_None = 0x0,
+    CPKTableFlag_IsFile = 0x1,         //是否是合法文件？
+    CPKTableFlag_IsDir = 0x2,          //是否是目录
+    CPKTableFlag_Unknown2 = 0x4,
+    CPKTableFlag_Unknown3 = 0x8,
+    CPKTableFlag_IsDeleted = 0x10,     //是否已删除
 
 };
 
 
-struct CpkFileEntry {
-    unsigned int vCRC;                  //0x00  当前节点CRC
-    CpkFileAttrib Attrib;               //0x04  文件属性信息
-    DWORD vParentCRC;                   //0x08  父节点CRC，根节点为0
-    unsigned int Offset;                //0x0C  压缩后的数据在CPK中的偏移量。
-    unsigned int CompressedSize;        //0x10  压缩后数据的大小。对于目录，这个值为0。
-    unsigned int OriginalSize;          //0x14  原始文件的大小，方便你解压时开缓冲区。
-    unsigned int InfoRecordSize;        //0x18  文件名信息偏移 信息紧跟着压缩数据之后，所以从Offset + CompressedSize读取InfoRecordSize，最开头就是文件名
+struct CPKTable {
+    DWORD dwCRC;                    //0x00  当前节点CRC
+    CPKTableFlag dwFlag;            //0x04  文件属性信息
+    DWORD dwFatherCRC;              //0x08  父节点CRC，根节点为0
+    DWORD dwStartPos;               //0x0C  压缩后的数据在CPK中的偏移量。
+    DWORD dwPackedSize;             //0x10  压缩后数据的大小。对于目录，这个值为0。
+    DWORD dwOriginSize;             //0x14  原始文件的大小，方便你解压时开缓冲区。
+    DWORD dwExtraInfoSize;          //0x18  文件名信息偏移 信息紧跟着压缩数据之后，所以从Offset + CompressedSize读取InfoRecordSize，最开头就是文件名
 };
 
 class CPKFile {
 public:
-    bool bOpened;                   //0x110     是否打开
-    DWORD vCRC;                     //0x114     本节点CRC
-    DWORD vParentCRC;               //0x118     父节点CRC
-    DWORD fileIndex;                //0x11C     文件数组下标
-    LPVOID lpMapFileBase;           //0x120     文件映射基址
-    void* pSrc;                     //0x124     文件原始缓冲
-    DWORD srcOffset;                //0x128     对齐字节
-    bool isCompressed;              //0x12C     是否是压缩文件
-    void* pDest;                    //0x130     解压缓冲区
-    DWORD originalSize;             //0x134     原始文件大小
-    DWORD fileOffset;               //0x138     文件偏移
-    CpkFileEntry* pRecordEntry;     //0x13C     文件结构指针
+    bool bValid;                    //0x110 是否有效
+    DWORD dwCRC;                    //0x114 
+    DWORD dwFatherCRC;              //0x118 父节点CRC
+    DWORD nTableIndex;              //0x11C 文件数组下标
+    LPVOID lpMapAddress;            //0x120 文件映射基址
+    void* lpStartAddress;           //0x124 文件原始缓冲
+    DWORD dwOffset;                 //0x128 对齐偏移量
+    bool bCompressed;               //0x12C 是否是压缩文件
+    void* lpMem;                    //0x130 一般存放解压缩内容
+    DWORD dwFileSize;               //0x134 原始文件大小
+    DWORD dwPointer;                //0x138 文件指针
+    CPKTable* pRecordEntry;         //0x13C 文件结构指针
 };
 
 //0x140
-struct gbVFile {
-    DWORD unknown1;                 //0x0
-    DWORD unknown2;                 //0x4
-    DWORD unknown3;                 //0x8
+struct gbVFile : CPKFile {
+    DWORD OpenMode;                 //0x0
+    DWORD EntryAddr;                 //0x4
+    DWORD FileSize;                 //0x8
     char fileName[MAX_PATH];        //0xC       文件名
-    CPKFile cpkFile;                //0x110     文件信息结构
+    CPKFile cpkFile;
 };
 
 
@@ -65,20 +65,28 @@ struct CpkZipUnzipParam {
 };
 
 //0x80
-struct CpkHeader {
-    unsigned int signature; //0x0
-    DWORD dwCheckFlag;      //0x4   合法的CPK文件此处值必须为1
-    DWORD unknown[0x2];     //0x08
-    DWORD entryCapacity;    //0x10  CpkFileEntry数组容量
-    DWORD unknown2[0x3];    //0x14
-    unsigned int dwCount;   //0x20  CpkFileEntry数组数量
-    char unknown3[0x5C];    //0x24
+struct CPKHeader {
+    DWORD dwLable;           //0x0
+    DWORD dwVersion;         //0x4   版本 必须为1
+    DWORD dwTableStart;      //0x08
+    DWORD dwDataStart;       //0x0C
+    DWORD dwMaxFileNum;      //0x10  最大文件数量
+    DWORD dwFileNum;         //0x14  文件数量
+    DWORD dwIsFormatted;     //0x18
+    DWORD dwSizeOfHeader;    //0x1C
+    DWORD dwValidTableNum;   //0x20  CpkFileEntry数组数量
+    DWORD dwMaxTableNum;     //0x24
+    DWORD dwFragmentNum;     //0x28
+    DWORD dwPackageSize;     //0x2C
+    DWORD dwReserved[20];    //0x30
 };
 
 enum ECPKMode {
-    ECPKMode_None = 0,
-    ECPKMode_File = 1,
-    ECPKMode_Mapped = 2,
+    CPKM_Null = 0,
+    CPKM_Normal = 1,
+    CPKM_FileMapping = 2,
+    CPKM_Overlapped = 3,
+    CPKM_End = 4,
 };
 
 enum ECPKSeekFileType {
@@ -91,7 +99,7 @@ class CPKDirectoryEntry {
 
 public:
     CPKDirectoryEntry()
-        :vCRC(0), vParentCRC(0), lpszName{ 0 }, iAttrib(CpkFileAttrib_None)
+        :vCRC(0), vParentCRC(0), lpszName{ 0 }, iAttrib(CPKTableFlag_None)
     {
     }
     ~CPKDirectoryEntry()
@@ -102,7 +110,7 @@ public:
     }
     DWORD vCRC;
     DWORD vParentCRC;
-    CpkFileAttrib iAttrib;
+    CPKTableFlag iAttrib;
     CHAR lpszName[MAX_PATH];
     std::vector<CPKDirectoryEntry*> childs;
 };
@@ -134,8 +142,8 @@ public:
     void Rewind(CPKFile *pCpkFile);
     void SetOpenMode(ECPKMode openMode);
 
-    bool buildDirectoryTree(CPKDirectoryEntry& entry);
-    bool buildParent(CpkFileEntry& currEntry, std::map<DWORD, CPKDirectoryEntry*>& handledEntries);
+    bool BuildDirectoryTree(CPKDirectoryEntry& entry);
+    bool buildParent(CPKTable& currEntry, std::map<DWORD, CPKDirectoryEntry*>& handledEntries);
 
 private:
     int executeZipUnZip(CpkZipUnzipParam *param);
@@ -150,22 +158,22 @@ private:
     static void InitCrcTable(void);
     DWORD GetAllocationGranularity(void);
     void Reset();
-    bool ReadFileEntryName(const CpkFileEntry* pFileEntry, char* lpBuffer, DWORD bufferLen);
+    bool ReadFileEntryName(const CPKTable* pFileEntry, char* lpBuffer, DWORD bufferLen);
 
 
 
 
 private:
     DWORD dwAllocationGranularity;                  //0x0           块对齐长度，做文件映射时需要对齐到该长度，否则映射失败
-    ECPKMode dwOpenMode;                            //0x4           打开模式 当前为ECPKMode_Mapped
-    CpkHeader cpkHeader;                            //0x8           文件头信息
-    CpkFileEntry entries[0x8000];                   //0x88          文件节点信息数组，通过哈希存储
-    gbVFile* vFiles[0x8];                           //0xE0088       文件数组
-    bool isLoaded;                                  //0xE00A8       是否已加载
-    HANDLE fileHandle;                              //0xE0090       文件句柄
-    HANDLE fileMappingHandle;                       //0xE0094       文件映射句柄
+    ECPKMode m_eMode;                               //0x4           打开模式 当前为ECPKMode_Mapped
+    CPKHeader cpkHeader;                            //0x8           文件头信息
+    CPKTable entries[32768];                    //0x88          文件节点信息数组，通过哈希存储
+    gbVFile* m_pgbVFile[0x8];                       //0xE0088       文件数组
+    bool m_bLoaded;                                 //0xE00A8       是否已加载
+    HANDLE m_dwCPKHandle;                           //0xE0090       文件句柄
+    HANDLE m_dwCPKMappingHandle;                    //0xE0094       文件映射句柄
     char fileName[MAX_PATH];                        //0xE0098       CPK文件名
-    DWORD dwVFileOpenedCount;                       //0xE009C       当前打开的gbVFile文件数量
+    DWORD m_nOpenedFileNum;                         //0xE009C       当前打开的gbVFile文件数量
 
 private:
     static DWORD *CrcTable[256];

--- a/tools/Pal3CpkTool/Pal3CpkTool/CPK.h
+++ b/tools/Pal3CpkTool/Pal3CpkTool/CPK.h
@@ -91,7 +91,7 @@ class CPKDirectoryEntry {
 
 public:
     CPKDirectoryEntry()
-        :vCRC(0), vParentCRC(0), lpszName{ 0 }, iAttrib(0)
+        :vCRC(0), vParentCRC(0), lpszName{ 0 }, iAttrib(CpkFileAttrib_None)
     {
     }
     ~CPKDirectoryEntry()
@@ -102,7 +102,7 @@ public:
     }
     DWORD vCRC;
     DWORD vParentCRC;
-    DWORD iAttrib;
+    CpkFileAttrib iAttrib;
     CHAR lpszName[MAX_PATH];
     std::vector<CPKDirectoryEntry*> childs;
 };
@@ -122,6 +122,7 @@ public:
     bool Unload(void);
     char * ReadLine(char *lpBuffer, int ReadSize, CPKFile *pCpkFile);
     CPKFile* Open(const char *lpString2);
+    CPKFile* Open(DWORD vCRC, const char* saveFileName);
     char ReadChar(CPKFile * pCpkFile);
     DWORD Compress(void *dest, void *src, unsigned int size);
     DWORD DeCompress(void *dest, void *src, DWORD compressedSize);
@@ -138,8 +139,8 @@ public:
 
 private:
     int executeZipUnZip(CpkZipUnzipParam *param);
-    int processCompress(unsigned __int8 *src, unsigned int decompressSize, unsigned char *dest, DWORD *bResult, int encryptTable);
-    int processDeCompress(unsigned __int8 *src, int decompressSize, unsigned char *dest, DWORD *resultSize);
+    gbVFile* OpenTableIndex(int iFileIndex);
+
 
     bool GetFileSize(DWORD &CompressedSize, DWORD &OriginalSize, DWORD targetCRC);
     bool IsDir(DWORD dwTargetCRC);
@@ -168,5 +169,6 @@ private:
 
 private:
     static DWORD *CrcTable[256];
+    static void* lzo_wrkmem;
 };
 

--- a/tools/Pal3CpkTool/Pal3CpkTool/Pal3CpkTool.vcxproj
+++ b/tools/Pal3CpkTool/Pal3CpkTool/Pal3CpkTool.vcxproj
@@ -153,10 +153,13 @@
   <ItemGroup>
     <ClCompile Include="CPK.cpp" />
     <ClCompile Include="main.cpp" />
+    <ClCompile Include="minilzo\minilzo.c" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="CPK.h" />
     <ClInclude Include="ida_struct.h" />
+    <ClInclude Include="minilzo\lzoconf.h" />
+    <ClInclude Include="minilzo\minilzo.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/tools/Pal3CpkTool/Pal3CpkTool/Pal3CpkTool.vcxproj.filters
+++ b/tools/Pal3CpkTool/Pal3CpkTool/Pal3CpkTool.vcxproj.filters
@@ -13,6 +13,9 @@
       <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
       <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
     </Filter>
+    <Filter Include="minilzo">
+      <UniqueIdentifier>{39702096-6e68-4aea-a056-2753ee83aa98}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp">
@@ -21,6 +24,9 @@
     <ClCompile Include="CPK.cpp">
       <Filter>源文件</Filter>
     </ClCompile>
+    <ClCompile Include="minilzo\minilzo.c">
+      <Filter>minilzo</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="CPK.h">
@@ -28,6 +34,12 @@
     </ClInclude>
     <ClInclude Include="ida_struct.h">
       <Filter>头文件</Filter>
+    </ClInclude>
+    <ClInclude Include="minilzo\minilzo.h">
+      <Filter>minilzo</Filter>
+    </ClInclude>
+    <ClInclude Include="minilzo\lzoconf.h">
+      <Filter>minilzo</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/tools/Pal3CpkTool/Pal3CpkTool/ida_struct.h
+++ b/tools/Pal3CpkTool/Pal3CpkTool/ida_struct.h
@@ -32,7 +32,7 @@ struct CPKFile {
     LPVOID lpMapFileBase;           //0x120
     void* pSrc;                     //0x124
     DWORD srcOffset;                   //0x128
-    bool bFlag;                     //0x12C
+    bool isCompressed;                     //0x12C
     void* pDest;                    //0x130
     DWORD originalSize;             //0x134
     DWORD fileOffset;                   //0x138

--- a/tools/Pal3CpkTool/Pal3CpkTool/ida_struct.h
+++ b/tools/Pal3CpkTool/Pal3CpkTool/ida_struct.h
@@ -3,40 +3,40 @@
 /* 供IDA读取的头文件                                                    */
 /************************************************************************/
 
-struct CpkFileEntry {
-    unsigned int vCRC;              //据我猜测应该是根据文件名Hash出的一个数值，若干个Index结构在CPK文件中就是按这个数值升序排列的。
+struct CPKTable {
+    unsigned int dwCRC;              //据我猜测应该是根据文件名Hash出的一个数值，若干个Index结构在CPK文件中就是按这个数值升序排列的。
                                     //这样的好处是只要计算出要访问文件的CRC，就可以利用二分查找在对数时间内定位该文件的Index，进而读取数据。
 
-    unsigned int Attrib;            //0002,0001都是文件, 区别忘了貌似是一个是压缩一个是未压缩. 而0011是已删除的文件, 0003是目录. 或许也会有0013表示已删除的目录
+    unsigned int dwFlag;            //0002,0001都是文件, 区别忘了貌似是一个是压缩一个是未压缩. 而0011是已删除的文件, 0003是目录. 或许也会有0013表示已删除的目录
 
-    unsigned int vParentCRC;        //一个CRC值，等于它的父目录的CRC。CPK文件支持子目录，当你定位好一个文件的index后，通过这个指针反复向上层遍历，
+    unsigned int dwFatherCRC;        //一个CRC值，等于它的父目录的CRC。CPK文件支持子目录，当你定位好一个文件的index后，通过这个指针反复向上层遍历，
                                     //就可以取得它的完整的存储路径。在根目录下的文件的Index中此值为0。
 
-    unsigned int Offset;            //压缩后的数据在CPK中的偏移量。
+    unsigned int dwStartPos;            //压缩后的数据在CPK中的偏移量。
 
-    unsigned int CompressedSize;    //压缩后数据的大小。对于目录，这个值为0。
+    unsigned int dwPackedSize;    //压缩后数据的大小。对于目录，这个值为0。
 
-    unsigned int OriginalSize;      //原始文件的大小，方便你解压时开缓冲区。
+    unsigned int dwOriginSize;      //原始文件的大小，方便你解压时开缓冲区。
 
-    unsigned int InfoRecordSize;    /*奇怪的参数。对于每一个Index所代表的文件，压缩后的数据在CPK中从index.Offset起开始存储，占用index.CompressedSize的空间，
+    unsigned int dwExtraInfoSize;    /*奇怪的参数。对于每一个Index所代表的文件，压缩后的数据在CPK中从index.Offset起开始存储，占用index.CompressedSize的空间，
                                       接下来就是一个大小为InfoRecordSize的奇怪记录，我只知道这个记录的一开头就是文件名，以#0结束，其他的都不清楚，有兴趣的可以研究一下。
                                       需要注意的是，只要InfoRecordSize为0，或这个Index不是目录，但CompressedSize为0，这个Index就毫无疑义，不需处理。
                                       我因为多次运行升级程序（为了调试它来研究CPK格式），文件中已有好多这样的无效Index了。*/
 };
 
 struct CPKFile {
-    bool bOpened;                     //0x110
-    DWORD vCRC;                      //0x114
-    DWORD vParentCRC;                //0x118
-    DWORD fileIndex;                //0x11C
-    LPVOID lpMapFileBase;           //0x120
-    void* pSrc;                     //0x124
-    DWORD srcOffset;                   //0x128
-    bool isCompressed;                     //0x12C
-    void* pDest;                    //0x130
-    DWORD originalSize;             //0x134
-    DWORD fileOffset;                   //0x138
-    CpkFileEntry* pRecordEntry;     //0x13C
+    bool bValid;                     //0x110
+    DWORD dwCRC;                      //0x114
+    DWORD dwFatherCRC;                //0x118
+    DWORD nTableIndex;                //0x11C
+    LPVOID lpMapAddress;           //0x120
+    void* lpStartAddress;                     //0x124
+    DWORD dwOffset;                   //0x128
+    bool bCompressed;                     //0x12C
+    void* lpMem;                    //0x130
+    DWORD dwFileSize;             //0x134
+    DWORD dwPointer;                   //0x138
+    CPKTable* pRecordEntry;     //0x13C
 };
 
 //0x140
@@ -63,26 +63,26 @@ struct CpkZipUnzipParam {
 };
 
 //0x80
-struct CpkHeader {
-    unsigned int signature; //0x0
-    DWORD dwCheckFlag;      //0x4  合法的CPK文件此处值必须为1
+struct CPKHeader {
+    unsigned int dwLable; //0x0
+    DWORD dwVersion;      //0x4  合法的CPK文件此处值必须为1
     DWORD unknown[0x2];     //0x08
-    DWORD entryCapacity;    //0x10
+    DWORD dwMaxFileNum;    //0x10
     DWORD unknown2[0x3];    //0x14
-    unsigned int dwCount;   //0x20
+    unsigned int dwValidTableNum;   //0x20
     char unknown3[0x5C];
 };
 
 
 struct CPK {
     unsigned long dwAllocationGranularity;      //0x0
-    unsigned long dwOpenMode;                   //0x4
-    CpkHeader cpkHeader;                        //0x8
-    CpkFileEntry entries[0x8000];               //0x88
-    gbVFile* vFiles[0x8];                        //0xE0088
-    bool isLoaded;                              //0xE00A8
-    HANDLE fileHandle;                          //0xE0090
-    HANDLE fileMappingHandle;                   //0xE0094
+    unsigned long m_eMode;                   //0x4
+    CPKHeader cpkHeader;                        //0x8
+    CPKTable entries[0x8000];               //0x88
+    gbVFile* m_pgbVFile[0x8];                        //0xE0088
+    bool m_bLoaded;                              //0xE00A8
+    HANDLE m_dwCPKHandle;                          //0xE0090
+    HANDLE m_dwCPKMappingHandle;                   //0xE0094
     char fileName[MAX_PATH];                    //0xE0098
-    DWORD dwVFileOpenedCount;                        //0xE009C
+    DWORD m_nOpenedFileNum;                        //0xE009C
 };

--- a/tools/Pal3CpkTool/Pal3CpkTool/ida_struct.h
+++ b/tools/Pal3CpkTool/Pal3CpkTool/ida_struct.h
@@ -84,5 +84,5 @@ struct CPK {
     HANDLE fileHandle;                          //0xE0090
     HANDLE fileMappingHandle;                   //0xE0094
     char fileName[MAX_PATH];                    //0xE0098
-    DWORD dwVFileOpened;                        //0xE009C
+    DWORD dwVFileOpenedCount;                        //0xE009C
 };

--- a/tools/Pal3CpkTool/Pal3CpkTool/main.cpp
+++ b/tools/Pal3CpkTool/Pal3CpkTool/main.cpp
@@ -4,26 +4,124 @@
 #include <iostream>
 #include <fstream>
 #include <windows.h>
+#include <io.h>
+#include <direct.h> 
+#include <cassert>
 #include "cpk.h"
 
-int main()
+#ifdef WIN32
+#define ACCESS(fileName,accessMode) _access(fileName,accessMode)
+#define MKDIR(path) _mkdir(path)
+#else
+#define ACCESS(fileName,accessMode) access(fileName,accessMode)
+#define MKDIR(path) mkdir(path,S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH)
+#endif
+
+int32_t createDirectory(const std::string &directoryPath)
 {
-    //测试CPK接口
-    std::string filePath = R"(E:\PAL3\basedata\basedata.cpk)";
+    uint32_t dirPathLen = directoryPath.length();
+    if (dirPathLen > MAX_PATH) {
+        return -1;
+    }
+    char tmpDirPath[MAX_PATH] = { 0 };
+    for (uint32_t i = 0; i < dirPathLen; ++i) {
+        tmpDirPath[i] = directoryPath[i];
+        if (tmpDirPath[i] == '\\' || tmpDirPath[i] == '/') {
+            if (ACCESS(tmpDirPath, 0) != 0) {
+                int32_t ret = MKDIR(tmpDirPath);
+                if (ret != 0) {
+                    return ret;
+                }
+            }
+        }
+    }
+    if (ACCESS(directoryPath.c_str(), 0) != 0) {
+        int32_t ret = MKDIR(directoryPath.c_str());
+        if (ret != 0) {
+            return ret;
+        }
+    }
+
+    return 0;
+}
+
+
+bool decompress(CPK* cpk, const char* rootPath, CPKDirectoryEntry* pDirectoryEntry) {
+    char absPath[MAX_PATH] = { 0 };
+    sprintf_s(absPath, sizeof(absPath), "%s\\%s", rootPath, pDirectoryEntry->lpszName);
+    if (pDirectoryEntry->iAttrib & CpkFileAttrib_IsDir) {
+        createDirectory(absPath);
+        for (int i = 0; i < pDirectoryEntry->childs.size(); i++) {
+            decompress(cpk, rootPath, pDirectoryEntry->childs[i]);
+        }
+    } else {
+        //open file and decompress it
+        if (!strlen(pDirectoryEntry->lpszName))
+            return true;
+        CPKFile* pFile = cpk->Open(pDirectoryEntry->lpszName);
+        if (!pFile)
+            return false;
+        assert(pFile);
+        HANDLE hFile = CreateFileA(absPath, GENERIC_WRITE, FILE_SHARE_WRITE, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
+        if (hFile == INVALID_HANDLE_VALUE) {
+            DWORD dwError = GetLastError();
+            assert(false);
+        }
+        DWORD dwBytesWritten;
+        BOOL bOk = WriteFile(hFile, pFile->pDest, pFile->originalSize, &dwBytesWritten, NULL);
+        assert(bOk && dwBytesWritten == pFile->originalSize);
+        CloseHandle(hFile);
+        cpk->Close(pFile);
+    }
+    return true;
+}
+
+//获取cpk文件的baseName
+std::string getBaseFileName(const std::string cpkFullPath)
+{
+    auto pos1 = cpkFullPath.find(".cpk");
+    if (pos1 == std::string::npos)
+        return "";
+    auto pos2 = cpkFullPath.find_last_of("\\");
+    if (pos2 == std::string::npos)
+        pos2 = cpkFullPath.find_last_not_of("/");
+    if (pos2 == std::string::npos) {
+        return "";
+    }
+    pos2 += 1;
+    std::string fileBaseName = cpkFullPath.substr(pos2, pos1 - pos2);
+    return fileBaseName;
+}
+
+//CPK解压工具 cpk文件路径 解压路径
+int main(int argc, char** argv)
+{
+    if (argc < 3) {
+        printf("argument too less!");
+        return -1;
+    }
+
+    std::string cpkFilePath = argv[1];
+    std::string saveRootPath = argv[2];
+
+    createDirectory(saveRootPath);
+
     CPK cpk;
-    bool bOk = cpk.Load(filePath.c_str());
+    bool bOk = cpk.Load(cpkFilePath.c_str());
     if (!bOk)
         return -1;
-    CPKFile* pCpkFile = cpk.Open("cbdata\\memoryLogFile.log");
-    if (!pCpkFile)
+
+    std::string fileBaseName = getBaseFileName(cpkFilePath);
+    if (!fileBaseName.length())
         return -1;
-    int origianlSize = pCpkFile->originalSize;
-    cpk.Close(pCpkFile);
-    char* lpBuf = new char[origianlSize + 1];
-    memset(lpBuf, 0, sizeof(lpBuf));
-    bOk = cpk.LoadFile(lpBuf, "cbdata\\memoryLogFile.log");
-    lpBuf[origianlSize] = '\0';
-    int len = strlen(lpBuf);
-    delete[] lpBuf;
+
+    //为输出目录拼接cpk baseName
+    saveRootPath.append("\\").append(fileBaseName);
+    CPKDirectoryEntry entry;
+    cpk.buildDirectoryTree(entry);
+    for (int i = 0; i < entry.childs.size(); i++) {
+        CPKDirectoryEntry* pChild = entry.childs[i];
+        decompress(&cpk, saveRootPath.c_str(), pChild);
+    }
     return 0;
 }

--- a/tools/Pal3CpkTool/Pal3CpkTool/minilzo/lzoconf.h
+++ b/tools/Pal3CpkTool/Pal3CpkTool/minilzo/lzoconf.h
@@ -1,0 +1,371 @@
+/* lzoconf.h -- configuration for the LZO real-time data compression library
+
+   This file is part of the LZO real-time data compression library.
+
+   Copyright (C) 1998 Markus Franz Xaver Johannes Oberhumer
+   Copyright (C) 1997 Markus Franz Xaver Johannes Oberhumer
+   Copyright (C) 1996 Markus Franz Xaver Johannes Oberhumer
+
+   The LZO library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU General Public License as
+   published by the Free Software Foundation; either version 2 of
+   the License, or (at your option) any later version.
+
+   The LZO library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with the LZO library; see the file COPYING.
+   If not, write to the Free Software Foundation, Inc.,
+   59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+
+   Markus F.X.J. Oberhumer
+   <markus.oberhumer@jk.uni-linz.ac.at>
+   http://wildsau.idv.uni-linz.ac.at/mfx/lzo.html
+ */
+
+
+#ifndef __LZOCONF_H
+#define __LZOCONF_H
+
+#define LZO_VERSION             0x1040
+#define LZO_VERSION_STRING      "1.04"
+#define LZO_VERSION_DATE        "Mar 15 1998"
+
+/* internal Autoconf configuration file - only used when building LZO */
+#if defined(LZO_HAVE_CONFIG_H)
+#  include <config.h>
+#endif
+#include <limits.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/***********************************************************************
+// LZO requires a conforming <limits.h>
+************************************************************************/
+
+#if !defined(CHAR_BIT) || (CHAR_BIT != 8)
+#  error "invalid CHAR_BIT"
+#endif
+#if !defined(UCHAR_MAX) || !defined(UINT_MAX) || !defined(ULONG_MAX)
+#  error "check your compiler installation"
+#endif
+#if (USHRT_MAX < 1 ) || (UINT_MAX < 1) || (ULONG_MAX < 1)
+#  error "your limits.h macros are broken"
+#endif
+
+/* workaround a cpp bug under hpux 10.20 */
+#define LZO_0xffffffffL     4294967295ul
+
+
+/***********************************************************************
+// architecture defines
+************************************************************************/
+
+#if !defined(__LZO_WIN) && !defined(__LZO_DOS) && !defined(__LZO_OS2)
+#  if defined(__WINDOWS__) || defined(_WINDOWS) || defined(_Windows)
+#    define __LZO_WIN
+#  elif defined(__WIN32__) || defined(_WIN32) || defined(WIN32)
+#    define __LZO_WIN
+#  elif defined(__NT__) || defined(__NT_DLL__) || defined(__WINDOWS_386__)
+#    define __LZO_WIN
+#  elif defined(__DOS__) || defined(__MSDOS__) || defined(MSDOS)
+#    define __LZO_DOS
+#  elif defined(__OS2__) || defined(__OS2V2__) || defined(OS2)
+#    define __LZO_OS2
+#  elif defined(__palmos__)
+#    define __LZO_PALMOS
+#  elif defined(__TOS__) || defined(__atarist__)
+#    define __LZO_TOS
+#  endif
+#endif
+
+#if (UINT_MAX < LZO_0xffffffffL)
+#  if defined(__LZO_WIN)
+#    define __LZO_WIN16
+#  elif defined(__LZO_DOS)
+#    define __LZO_DOS16
+#  elif defined(__LZO_PALMOS)
+#    define __LZO_PALMOS16
+#  elif defined(__LZO_TOS)
+#    define __LZO_TOS16
+#  else
+#    error "16-bit target not supported - contact me for porting hints"
+#  endif
+#endif
+
+#if !defined(__LZO_i386)
+#  if defined(__LZO_DOS) || defined(__LZO_WIN16)
+#    define __LZO_i386
+#  elif defined(__i386__) || defined(__386__) || defined(_M_IX86)
+#    define __LZO_i386
+#  endif
+#endif
+
+#if defined(__LZO_STRICT_16BIT)
+#  if (UINT_MAX < LZO_0xffffffffL)
+#    include <lzo16bit.h>
+#  endif
+#endif
+
+
+/***********************************************************************
+// integral and pointer types
+************************************************************************/
+
+/* Integral types with 32 bits or more */
+#if !defined(LZO_UINT32_MAX)
+#  if (UINT_MAX >= LZO_0xffffffffL)
+     typedef unsigned int       lzo_uint32;
+     typedef int                lzo_int32;
+#    define LZO_UINT32_MAX      UINT_MAX
+#    define LZO_INT32_MAX       INT_MAX
+#    define LZO_INT32_MIN       INT_MIN
+#  elif (ULONG_MAX >= LZO_0xffffffffL)
+     typedef unsigned long      lzo_uint32;
+     typedef long               lzo_int32;
+#    define LZO_UINT32_MAX      ULONG_MAX
+#    define LZO_INT32_MAX       LONG_MAX
+#    define LZO_INT32_MIN       LONG_MIN
+#  else
+#    error "lzo_uint32"
+#  endif
+#endif
+
+/* lzo_uint is used like size_t */
+#if !defined(LZO_UINT_MAX)
+#  if (UINT_MAX >= LZO_0xffffffffL)
+     typedef unsigned int       lzo_uint;
+     typedef int                lzo_int;
+#    define LZO_UINT_MAX        UINT_MAX
+#    define LZO_INT_MAX         INT_MAX
+#    define LZO_INT_MIN         INT_MIN
+#  elif (ULONG_MAX >= LZO_0xffffffffL)
+     typedef unsigned long      lzo_uint;
+     typedef long               lzo_int;
+#    define LZO_UINT_MAX        ULONG_MAX
+#    define LZO_INT_MAX         LONG_MAX
+#    define LZO_INT_MIN         LONG_MIN
+#  else
+#    error "lzo_uint"
+#  endif
+#endif
+
+
+/* Memory model that allows to access memory at offsets of lzo_uint.
+ * `Huge' pointers (16-bit DOS/Windows) are somewhat slow, but they
+ * work fine and I really don't care about 16-bit compiler
+ * optimizations nowadays.
+ */
+#if !defined(__LZO_MMODEL)
+#  if (LZO_UINT_MAX <= UINT_MAX)
+#    define __LZO_MMODEL
+#  elif defined(__LZO_DOS16) || defined(__LZO_WIN16)
+#    define __LZO_MMODEL        __huge
+#    define LZO_999_UNSUPPORTED
+#  elif defined(__LZO_PALMOS16) || defined(__LZO_TOS16)
+#    define __LZO_MMODEL
+#  else
+#    error "__LZO_MMODEL"
+#  endif
+#endif
+
+/* no typedef here because of const-pointer issues */
+#define lzo_byte                unsigned char __LZO_MMODEL
+#define lzo_bytep               unsigned char __LZO_MMODEL *
+#define lzo_charp               char __LZO_MMODEL *
+#define lzo_voidp               void __LZO_MMODEL *
+#define lzo_shortp              short __LZO_MMODEL *
+#define lzo_ushortp             unsigned short __LZO_MMODEL *
+#define lzo_uint32p             lzo_uint32 __LZO_MMODEL *
+#define lzo_int32p              lzo_int32 __LZO_MMODEL *
+#define lzo_uintp               lzo_uint __LZO_MMODEL *
+#define lzo_intp                lzo_int __LZO_MMODEL *
+#define lzo_voidpp              lzo_voidp __LZO_MMODEL *
+#define lzo_bytepp              lzo_bytep __LZO_MMODEL *
+
+typedef int lzo_bool;
+
+#ifndef lzo_sizeof_dict_t
+#  define lzo_sizeof_dict_t     sizeof(lzo_bytep)
+#endif
+
+
+/***********************************************************************
+// function types
+************************************************************************/
+
+/* linkage */
+#if !defined(__LZO_EXTERN_C)
+#  ifdef __cplusplus
+#    define __LZO_EXTERN_C      extern "C"
+#  else
+#    define __LZO_EXTERN_C      extern
+#  endif
+#endif
+
+/* calling conventions */
+#if !defined(__LZO_CDECL)
+#  if defined(__LZO_DOS16) || defined(__LZO_WIN16)
+#    define __LZO_CDECL         __far __cdecl
+#  elif defined(__LZO_i386) && defined(_MSC_VER)
+#    define __LZO_CDECL         __cdecl
+#  elif defined(__LZO_i386) && defined(__WATCOMC__)
+#    define __LZO_CDECL         __near __cdecl
+#  else
+#    define __LZO_CDECL
+#  endif
+#endif
+#if !defined(__LZO_ENTRY)
+#  define __LZO_ENTRY           __LZO_CDECL
+#endif
+
+/* DLL export information */
+#if !defined(__LZO_EXPORT1)
+#  define __LZO_EXPORT1
+#endif
+#if !defined(__LZO_EXPORT2)
+#  define __LZO_EXPORT2
+#endif
+
+/* calling convention for C functions */
+#if !defined(LZO_PUBLIC)
+#  define LZO_PUBLIC(_rettype)  __LZO_EXPORT1 _rettype __LZO_EXPORT2 __LZO_ENTRY
+#endif
+#if !defined(LZO_EXTERN)
+#  define LZO_EXTERN(_rettype)  __LZO_EXTERN_C LZO_PUBLIC(_rettype)
+#endif
+#if !defined(LZO_PRIVATE)
+#  define LZO_PRIVATE(_rettype) static _rettype __LZO_ENTRY
+#endif
+
+/* cdecl calling convention for assembler functions */
+#if !defined(LZO_PUBLIC_CDECL)
+#  define LZO_PUBLIC_CDECL(_rettype) \
+                __LZO_EXPORT1 _rettype __LZO_EXPORT2 __LZO_CDECL
+#endif
+#if !defined(LZO_EXTERN_CDECL)
+#  define LZO_EXTERN_CDECL(_rettype)  __LZO_EXTERN_C LZO_PUBLIC_CDECL(_rettype)
+#endif
+
+
+typedef int
+(__LZO_ENTRY *lzo_compress_t)   ( const lzo_byte *src, lzo_uint  src_len,
+                                        lzo_byte *dst, lzo_uint *dst_len,
+                                        lzo_voidp wrkmem );
+
+typedef int
+(__LZO_ENTRY *lzo_decompress_t) ( const lzo_byte *src, lzo_uint  src_len,
+                                        lzo_byte *dst, lzo_uint *dst_len,
+                                        lzo_voidp wrkmem );
+
+typedef int
+(__LZO_ENTRY *lzo_optimize_t)   (       lzo_byte *src, lzo_uint  src_len,
+                                        lzo_byte *dst, lzo_uint *dst_len,
+                                        lzo_voidp wrkmem );
+
+typedef int
+(__LZO_ENTRY *lzo_compress_dict_t)(const lzo_byte *src, lzo_uint  src_len,
+                                        lzo_byte *dst, lzo_uint *dst_len,
+                                        lzo_voidp wrkmem,
+                                  const lzo_byte *dict, lzo_uint dict_len );
+
+typedef int
+(__LZO_ENTRY *lzo_decompress_dict_t)(const lzo_byte *src, lzo_uint  src_len,
+                                        lzo_byte *dst, lzo_uint *dst_len,
+                                        lzo_voidp wrkmem,
+                                  const lzo_byte *dict, lzo_uint dict_len );
+
+
+/* a progress indicator callback function */
+typedef void (__LZO_ENTRY *lzo_progress_callback_t) (lzo_uint, lzo_uint);
+
+
+/***********************************************************************
+// error codes and prototypes
+************************************************************************/
+
+/* Error codes for the compression/decompression functions. Negative
+ * values are errors, positive values will be used for special but
+ * normal events.
+ */
+#define LZO_E_OK                    0
+#define LZO_E_ERROR                 (-1)
+#define LZO_E_OUT_OF_MEMORY         (-2)    /* not used right now */
+#define LZO_E_NOT_COMPRESSIBLE      (-3)    /* not used right now */
+#define LZO_E_INPUT_OVERRUN         (-4)
+#define LZO_E_OUTPUT_OVERRUN        (-5)
+#define LZO_E_LOOKBEHIND_OVERRUN    (-6)
+#define LZO_E_EOF_NOT_FOUND         (-7)
+#define LZO_E_INPUT_NOT_CONSUMED    (-8)
+
+
+/* lzo_init() should be the first function you call.
+ * Check the return code !
+ *
+ * lzo_init() is a macro to allow checking that the library and the
+ * compiler's view of various types are consistent.
+ */
+#define lzo_init() __lzo_init2(LZO_VERSION,(int)sizeof(short),(int)sizeof(int),\
+    (int)sizeof(long),(int)sizeof(lzo_uint32),(int)sizeof(lzo_uint),\
+    (int)lzo_sizeof_dict_t,(int)sizeof(char *),(int)sizeof(lzo_voidp),\
+    (int)sizeof(lzo_compress_t))
+LZO_EXTERN(int) __lzo_init2(unsigned,int,int,int,int,int,int,int,int,int);
+
+/* version functions (useful for shared libraries) */
+LZO_EXTERN(unsigned) lzo_version(void);
+LZO_EXTERN(const char *) lzo_version_string(void);
+LZO_EXTERN(const char *) lzo_version_date(void);
+LZO_EXTERN(const lzo_charp) _lzo_version_string(void);
+LZO_EXTERN(const lzo_charp) _lzo_version_date(void);
+
+/* string functions */
+LZO_EXTERN(int)
+lzo_memcmp(const lzo_voidp _s1, const lzo_voidp _s2, lzo_uint _len);
+LZO_EXTERN(lzo_voidp)
+lzo_memcpy(lzo_voidp _dest, const lzo_voidp _src, lzo_uint _len);
+LZO_EXTERN(lzo_voidp)
+lzo_memmove(lzo_voidp _dest, const lzo_voidp _src, lzo_uint _len);
+LZO_EXTERN(lzo_voidp)
+lzo_memset(lzo_voidp _s, int _c, lzo_uint _len);
+
+/* checksum functions */
+LZO_EXTERN(lzo_uint32)
+lzo_adler32(lzo_uint32 _adler, const lzo_byte *_buf, lzo_uint _len);
+LZO_EXTERN(lzo_uint32)
+lzo_crc32(lzo_uint32 _c, const lzo_byte *_buf, lzo_uint _len);
+
+/* memory allocation functions */
+LZO_EXTERN(lzo_bytep) lzo_alloc(lzo_uint _nelems, lzo_uint _size);
+LZO_EXTERN(lzo_bytep) lzo_malloc(lzo_uint _size);
+LZO_EXTERN(void) lzo_free(lzo_voidp _ptr);
+
+extern lzo_bytep (__LZO_ENTRY *lzo_alloc_hook) (lzo_uint,lzo_uint);
+extern void (__LZO_ENTRY *lzo_free_hook) (lzo_voidp);
+
+/* misc. */
+LZO_EXTERN(lzo_bool) lzo_assert(int _expr);
+LZO_EXTERN(int) _lzo_config_check(void);
+typedef union { lzo_bytep p; lzo_uint u; } __lzo_pu_u;
+typedef union { lzo_bytep p; lzo_uint32 u32; } __lzo_pu32_u;
+
+/* align a char pointer on a boundary that is a multiple of `size' */
+LZO_EXTERN(unsigned) __lzo_align_gap(const lzo_voidp _ptr, lzo_uint _size);
+#define LZO_PTR_ALIGN_UP(_ptr,_size) \
+    ((_ptr) + (lzo_uint) __lzo_align_gap((const lzo_voidp)(_ptr),(lzo_uint)(_size)))
+
+/* depracted - backward compatibility */
+#define LZO_ALIGN(_ptr,_size) LZO_PTR_ALIGN_UP(_ptr,_size)
+
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* already included */
+

--- a/tools/Pal3CpkTool/Pal3CpkTool/minilzo/minilzo.c
+++ b/tools/Pal3CpkTool/Pal3CpkTool/minilzo/minilzo.c
@@ -1,0 +1,2835 @@
+/* minilzo.c -- mini subset of the LZO real-time data compression library
+
+   This file is part of the LZO real-time data compression library.
+
+   Copyright (C) 1998 Markus Franz Xaver Johannes Oberhumer
+   Copyright (C) 1997 Markus Franz Xaver Johannes Oberhumer
+   Copyright (C) 1996 Markus Franz Xaver Johannes Oberhumer
+
+   The LZO library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU General Public License as
+   published by the Free Software Foundation; either version 2 of
+   the License, or (at your option) any later version.
+
+   The LZO library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with the LZO library; see the file COPYING.
+   If not, write to the Free Software Foundation, Inc.,
+   59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+
+   Markus F.X.J. Oberhumer
+   <markus.oberhumer@jk.uni-linz.ac.at>
+   http://wildsau.idv.uni-linz.ac.at/mfx/lzo.html
+ */
+
+/*
+ * NOTE:
+ *   the full LZO package can be found at
+ *   http://wildsau.idv.uni-linz.ac.at/mfx/lzo.html
+ */
+
+#define __LZO_IN_MINILZO
+
+#ifdef MINILZO_HAVE_CONFIG_H
+#  include <config.h>
+#endif
+
+#undef LZO_HAVE_CONFIG_H
+#include "minilzo.h"
+
+#if !defined(MINILZO_VERSION) || (MINILZO_VERSION != 0x1040)
+#  error "version mismatch in miniLZO source files"
+#endif
+
+#ifdef MINILZO_HAVE_CONFIG_H
+#  define LZO_HAVE_CONFIG_H
+#endif
+
+#if !defined(LZO_NO_SYS_TYPES_H)
+#  include <sys/types.h>
+#endif
+#include <stdio.h>
+
+#ifndef __LZO_CONF_H
+#define __LZO_CONF_H
+
+#if !defined(__LZO_IN_MINILZO)
+#  ifndef __LZOCONF_H
+#    include <lzoconf.h>
+#  endif
+#endif
+
+#if !defined(LZO_HAVE_CONFIG_H)
+#  include <stddef.h>
+#  include <string.h>
+#  if !defined(NO_STDLIB_H)
+#    include <stdlib.h>
+#  endif
+#  define HAVE_MEMCMP
+#  define HAVE_MEMCPY
+#  define HAVE_MEMMOVE
+#  define HAVE_MEMSET
+#else
+#  include <sys/types.h>
+#  if defined(STDC_HEADERS)
+#    include <string.h>
+#    include <stdlib.h>
+#  endif
+#  if defined(HAVE_STDDEF_H)
+#    include <stddef.h>
+#  endif
+#  if defined(HAVE_MEMORY_H)
+#    include <memory.h>
+#  endif
+#endif
+
+#if defined(__LZO_DOS16) || defined(__LZO_WIN16)
+#  define HAVE_MALLOC_H
+#  define HAVE_HALLOC
+#endif
+
+#undef NDEBUG
+#if !defined(LZO_DEBUG)
+#  define NDEBUG
+#endif
+#if defined(LZO_DEBUG) || !defined(NDEBUG)
+#  if !defined(NO_STDIO_H)
+#    include <stdio.h>
+#  endif
+#endif
+#include <assert.h>
+
+#if defined(__BOUNDS_CHECKING_ON)
+#  include <unchecked.h>
+#else
+#  define BOUNDS_CHECKING_OFF_DURING(stmt)      stmt
+#  define BOUNDS_CHECKING_OFF_IN_EXPR(expr)     (expr)
+#endif
+
+#if !defined(LZO_UNUSED)
+#  define LZO_UNUSED(parm)  (parm = parm)
+#endif
+
+#if !defined(__inline__) && !defined(__GNUC__)
+#  if defined(__cplusplus)
+#    define __inline__      inline
+#  else
+#    define __inline__
+#  endif
+#endif
+
+#if defined(NO_MEMCMP)
+#  undef HAVE_MEMCMP
+#endif
+
+#if !defined(HAVE_MEMCMP)
+#  undef memcmp
+#  define memcmp    lzo_memcmp
+#endif
+#if !defined(HAVE_MEMCPY)
+#  undef memcpy
+#  define memcpy    lzo_memcpy
+#endif
+#if !defined(HAVE_MEMMOVE)
+#  undef memmove
+#  define memmove   lzo_memmove
+#endif
+#if !defined(HAVE_MEMSET)
+#  undef memset
+#  define memset    lzo_memset
+#endif
+
+#if 1
+#  define LZO_BYTE(x)       ((unsigned char) (x))
+#else
+#  define LZO_BYTE(x)       ((unsigned char) ((x) & 0xff))
+#endif
+#if 0
+#  define LZO_USHORT(x)     ((unsigned short) (x))
+#else
+#  define LZO_USHORT(x)     ((unsigned short) ((x) & 0xffff))
+#endif
+
+#define LZO_MAX(a,b)        ((a) >= (b) ? (a) : (b))
+#define LZO_MIN(a,b)        ((a) <= (b) ? (a) : (b))
+#define LZO_MAX3(a,b,c)     ((a) >= (b) ? LZO_MAX(a,c) : LZO_MAX(b,c))
+#define LZO_MIN3(a,b,c)     ((a) <= (b) ? LZO_MIN(a,c) : LZO_MIN(b,c))
+
+#define lzo_sizeof(type)    ((lzo_uint) (sizeof(type)))
+
+#define LZO_HIGH(array)     ((lzo_uint) (sizeof(array)/sizeof(*(array))))
+
+#define LZO_SIZE(bits)      (1u << (bits))
+#define LZO_MASK(bits)      (LZO_SIZE(bits) - 1)
+
+#define LZO_LSIZE(bits)     (1ul << (bits))
+#define LZO_LMASK(bits)     (LZO_LSIZE(bits) - 1)
+
+#define LZO_USIZE(bits)     ((lzo_uint) 1 << (bits))
+#define LZO_UMASK(bits)     (LZO_USIZE(bits) - 1)
+
+#define LZO_STYPE_MAX(b)    (((1l  << (8*(b)-2)) - 1l)  + (1l  << (8*(b)-2)))
+#define LZO_UTYPE_MAX(b)    (((1ul << (8*(b)-1)) - 1ul) + (1ul << (8*(b)-1)))
+
+#if !defined(SIZEOF_UNSIGNED)
+#  if (UINT_MAX == 0xffff)
+#    define SIZEOF_UNSIGNED         2
+#  elif (UINT_MAX == LZO_0xffffffffL)
+#    define SIZEOF_UNSIGNED         4
+#  elif (UINT_MAX >= LZO_0xffffffffL)
+#    define SIZEOF_UNSIGNED         8
+#  else
+#    error SIZEOF_UNSIGNED
+#  endif
+#endif
+
+#if !defined(SIZEOF_UNSIGNED_LONG)
+#  if (ULONG_MAX == LZO_0xffffffffL)
+#    define SIZEOF_UNSIGNED_LONG    4
+#  elif (ULONG_MAX >= LZO_0xffffffffL)
+#    define SIZEOF_UNSIGNED_LONG    8
+#  else
+#    error SIZEOF_UNSIGNED_LONG
+#  endif
+#endif
+
+#if !defined(SIZEOF_SIZE_T)
+#  define SIZEOF_SIZE_T             SIZEOF_UNSIGNED
+#endif
+#if !defined(SIZE_T_MAX)
+#  define SIZE_T_MAX                LZO_UTYPE_MAX(SIZEOF_SIZE_T)
+#endif
+
+#if 1 && defined(__LZO_i386) && (UINT_MAX == LZO_0xffffffffL)
+#  if !defined(LZO_UNALIGNED_OK_2) && (USHRT_MAX == 0xffff)
+#    define LZO_UNALIGNED_OK_2
+#  endif
+#  if !defined(LZO_UNALIGNED_OK_4) && (LZO_UINT32_MAX == LZO_0xffffffffL)
+#    define LZO_UNALIGNED_OK_4
+#  endif
+#endif
+
+#if defined(LZO_UNALIGNED_OK_2) || defined(LZO_UNALIGNED_OK_4)
+#  if !defined(LZO_UNALIGNED_OK)
+#    define LZO_UNALIGNED_OK
+#  endif
+#endif
+
+#if defined(__LZO_NO_UNALIGNED)
+#  undef LZO_UNALIGNED_OK
+#  undef LZO_UNALIGNED_OK_2
+#  undef LZO_UNALIGNED_OK_4
+#endif
+
+#if defined(LZO_UNALIGNED_OK_2) && (USHRT_MAX != 0xffff)
+#  error "LZO_UNALIGNED_OK_2 must not be defined on this system"
+#endif
+#if defined(LZO_UNALIGNED_OK_4) && (LZO_UINT32_MAX != LZO_0xffffffffL)
+#  error "LZO_UNALIGNED_OK_4 must not be defined on this system"
+#endif
+
+#if defined(__LZO_NO_ALIGNED)
+#  undef LZO_ALIGNED_OK_4
+#endif
+
+#if defined(LZO_ALIGNED_OK_4) && (LZO_UINT32_MAX != LZO_0xffffffffL)
+#  error "LZO_ALIGNED_OK_4 must not be defined on this system"
+#endif
+
+#define LZO_LITTLE_ENDIAN       1234
+#define LZO_BIG_ENDIAN          4321
+#define LZO_PDP_ENDIAN          3412
+
+#if !defined(LZO_BYTE_ORDER)
+#  if defined(MFX_BYTE_ORDER)
+#    define LZO_BYTE_ORDER      MFX_BYTE_ORDER
+#  elif defined(__LZO_i386)
+#    define LZO_BYTE_ORDER      LZO_LITTLE_ENDIAN
+#  elif defined(BYTE_ORDER)
+#    define LZO_BYTE_ORDER      BYTE_ORDER
+#  elif defined(__BYTE_ORDER)
+#    define LZO_BYTE_ORDER      __BYTE_ORDER
+#  endif
+#endif
+
+#if defined(LZO_BYTE_ORDER)
+#  if (LZO_BYTE_ORDER != LZO_LITTLE_ENDIAN) && \
+      (LZO_BYTE_ORDER != LZO_BIG_ENDIAN)
+#    error "invalid LZO_BYTE_ORDER"
+#  endif
+#endif
+
+#if defined(LZO_UNALIGNED_OK) && !defined(LZO_BYTE_ORDER)
+#  error "LZO_BYTE_ORDER is not defined"
+#endif
+
+#define LZO_OPTIMIZE_GNUC_i386_IS_BUGGY
+
+#if defined(NDEBUG) && !defined(LZO_DEBUG) && !defined(__BOUNDS_CHECKING_ON)
+#  if defined(__GNUC__) && defined(__i386__)
+#    if !defined(LZO_OPTIMIZE_GNUC_i386_IS_BUGGY)
+#      define LZO_OPTIMIZE_GNUC_i386
+#    endif
+#  endif
+#endif
+
+__LZO_EXTERN_C int __lzo_init_done;
+__LZO_EXTERN_C const lzo_byte __lzo_copyright[];
+LZO_EXTERN(const lzo_byte *) lzo_copyright(void);
+__LZO_EXTERN_C const lzo_uint32 _lzo_crc32_table[256];
+
+#define _LZO_STRINGIZE(x)           #x
+#define _LZO_MEXPAND(x)             _LZO_STRINGIZE(x)
+
+#define _LZO_CONCAT2(a,b)           a ## b
+#define _LZO_CONCAT3(a,b,c)         a ## b ## c
+#define _LZO_CONCAT4(a,b,c,d)       a ## b ## c ## d
+#define _LZO_CONCAT5(a,b,c,d,e)     a ## b ## c ## d ## e
+
+#define _LZO_ECONCAT2(a,b)          _LZO_CONCAT2(a,b)
+#define _LZO_ECONCAT3(a,b,c)        _LZO_CONCAT3(a,b,c)
+#define _LZO_ECONCAT4(a,b,c,d)      _LZO_CONCAT4(a,b,c,d)
+#define _LZO_ECONCAT5(a,b,c,d,e)    _LZO_CONCAT5(a,b,c,d,e)
+
+#if 0
+
+#define __LZO_IS_COMPRESS_QUERY(i,il,o,ol,w)    ((lzo_voidp)(o) == (w))
+#define __LZO_QUERY_COMPRESS(i,il,o,ol,w,n,s) \
+		(*ol = (n)*(s), LZO_E_OK)
+
+#define __LZO_IS_DECOMPRESS_QUERY(i,il,o,ol,w)  ((lzo_voidp)(o) == (w))
+#define __LZO_QUERY_DECOMPRESS(i,il,o,ol,w,n,s) \
+		(*ol = (n)*(s), LZO_E_OK)
+
+#define __LZO_IS_OPTIMIZE_QUERY(i,il,o,ol,w)    ((lzo_voidp)(o) == (w))
+#define __LZO_QUERY_OPTIMIZE(i,il,o,ol,w,n,s) \
+		(*ol = (n)*(s), LZO_E_OK)
+
+#endif
+
+#ifndef __LZO_PTR_H
+#define __LZO_PTR_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if defined(__LZO_DOS16) || defined(__LZO_WIN16)
+#  include <dos.h>
+#  if 1 && defined(__WATCOMC__)
+#    include <i86.h>
+     __LZO_EXTERN_C unsigned char _HShift;
+#    define __LZO_HShift    _HShift
+#  elif 1 && defined(_MSC_VER)
+     __LZO_EXTERN_C unsigned short __near _AHSHIFT;
+#    define __LZO_HShift    ((unsigned) &_AHSHIFT)
+#  elif defined(__LZO_WIN16)
+#    define __LZO_HShift    3
+#  else
+#    define __LZO_HShift    12
+#  endif
+#  if !defined(_FP_SEG) && defined(FP_SEG)
+#    define _FP_SEG         FP_SEG
+#  endif
+#  if !defined(_FP_OFF) && defined(FP_OFF)
+#    define _FP_OFF         FP_OFF
+#  endif
+#endif
+
+#if (UINT_MAX >= LZO_0xffffffffL)
+   typedef ptrdiff_t            lzo_ptrdiff_t;
+#else
+   typedef long                 lzo_ptrdiff_t;
+#endif
+
+#if !defined(__LZO_HAVE_PTR_T)
+#  if defined(lzo_ptr_t)
+#    define __LZO_HAVE_PTR_T
+#  endif
+#endif
+#if !defined(__LZO_HAVE_PTR_T)
+#  if defined(SIZEOF_CHAR_P) && defined(SIZEOF_UNSIGNED_LONG)
+#    if (SIZEOF_CHAR_P == SIZEOF_UNSIGNED_LONG)
+       typedef unsigned long    lzo_ptr_t;
+       typedef long             lzo_sptr_t;
+#      define __LZO_HAVE_PTR_T
+#    endif
+#  endif
+#endif
+#if !defined(__LZO_HAVE_PTR_T)
+#  if defined(SIZEOF_CHAR_P) && defined(SIZEOF_UNSIGNED)
+#    if (SIZEOF_CHAR_P == SIZEOF_UNSIGNED)
+       typedef unsigned int     lzo_ptr_t;
+       typedef int              lzo_sptr_t;
+#      define __LZO_HAVE_PTR_T
+#    endif
+#  endif
+#endif
+#if !defined(__LZO_HAVE_PTR_T)
+#  if defined(SIZEOF_CHAR_P) && defined(SIZEOF_UNSIGNED_SHORT)
+#    if (SIZEOF_CHAR_P == SIZEOF_UNSIGNED_SHORT)
+       typedef unsigned short   lzo_ptr_t;
+       typedef short            lzo_sptr_t;
+#      define __LZO_HAVE_PTR_T
+#    endif
+#  endif
+#endif
+#if !defined(__LZO_HAVE_PTR_T)
+#  if defined(LZO_HAVE_CONFIG_H) || defined(SIZEOF_CHAR_P)
+#    error "no suitable type for lzo_ptr_t"
+#  else
+     typedef unsigned long      lzo_ptr_t;
+     typedef long               lzo_sptr_t;
+#    define __LZO_HAVE_PTR_T
+#  endif
+#endif
+
+#if defined(__LZO_DOS16) || defined(__LZO_WIN16)
+#define PTR(a)              ((lzo_bytep) (a))
+#define PTR_ALIGNED_4(a)    ((_FP_OFF(a) & 3) == 0)
+#define PTR_ALIGNED2_4(a,b) (((_FP_OFF(a) | _FP_OFF(b)) & 3) == 0)
+#else
+#define PTR(a)              ((lzo_ptr_t) (a))
+#define PTR_LINEAR(a)       PTR(a)
+#define PTR_ALIGNED_4(a)    ((PTR_LINEAR(a) & 3) == 0)
+#define PTR_ALIGNED_8(a)    ((PTR_LINEAR(a) & 7) == 0)
+#define PTR_ALIGNED2_4(a,b) (((PTR_LINEAR(a) | PTR_LINEAR(b)) & 3) == 0)
+#define PTR_ALIGNED2_8(a,b) (((PTR_LINEAR(a) | PTR_LINEAR(b)) & 7) == 0)
+#endif
+
+#define PTR_LT(a,b)         (PTR(a) < PTR(b))
+#define PTR_GE(a,b)         (PTR(a) >= PTR(b))
+#define PTR_DIFF(a,b)       ((lzo_ptrdiff_t) (PTR(a) - PTR(b)))
+
+LZO_EXTERN(lzo_ptr_t)
+__lzo_ptr_linear(const lzo_voidp ptr);
+
+typedef union
+{
+    char            a_char;
+    unsigned char   a_uchar;
+    short           a_short;
+    unsigned short  a_ushort;
+    int             a_int;
+    unsigned int    a_uint;
+    long            a_long;
+    unsigned long   a_ulong;
+    lzo_int         a_lzo_int;
+    lzo_uint        a_lzo_uint;
+    lzo_int32       a_lzo_int32;
+    lzo_uint32      a_lzo_uint32;
+    ptrdiff_t       a_ptrdiff_t;
+    lzo_ptrdiff_t   a_lzo_ptrdiff_t;
+    lzo_ptr_t       a_lzo_ptr_t;
+    char *          a_charp;
+    lzo_bytep       a_lzo_bytep;
+    lzo_bytepp      a_lzo_bytepp;
+}
+lzo_align_t;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+
+#define LZO_DETERMINISTIC
+
+#define LZO_DICT_USE_PTR
+#if defined(__LZO_DOS16) || defined(__LZO_WIN16) || defined(__LZO_STRICT_16BIT)
+#  undef LZO_DICT_USE_PTR
+#endif
+
+#if defined(LZO_DICT_USE_PTR)
+#  define lzo_dict_t    const lzo_bytep
+#  define lzo_dict_p    lzo_dict_t __LZO_MMODEL *
+#else
+#  define lzo_dict_t    lzo_uint
+#  define lzo_dict_p    lzo_dict_t __LZO_MMODEL *
+#endif
+
+#if !defined(lzo_moff_t)
+#define lzo_moff_t      lzo_uint
+#endif
+
+#endif
+
+LZO_PUBLIC(lzo_ptr_t)
+__lzo_ptr_linear(const lzo_voidp ptr)
+{
+    lzo_ptr_t p;
+
+#if defined(__LZO_DOS16) || defined(__LZO_WIN16)
+    p = (((lzo_ptr_t)(_FP_SEG(ptr))) << (16 - __LZO_HShift)) + (_FP_OFF(ptr));
+#else
+    p = PTR_LINEAR(ptr);
+#endif
+
+    return p;
+}
+
+LZO_PUBLIC(unsigned)
+__lzo_align_gap(const lzo_voidp ptr, lzo_uint size)
+{
+    lzo_ptr_t p, s, n;
+
+    assert(size > 0);
+
+    p = __lzo_ptr_linear(ptr);
+    s = (lzo_ptr_t) (size - 1);
+#if 0
+    assert((size & (size - 1)) == 0);
+    n = ((p + s) & ~s) - p;
+#else
+    n = (((p + s) / size) * size) - p;
+#endif
+
+    assert((long)n >= 0);
+    assert(n <= s);
+
+    return (unsigned)n;
+}
+
+#ifndef __LZO_UTIL_H
+#define __LZO_UTIL_H
+
+#ifndef __LZO_CONF_H
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if 1 && defined(HAVE_MEMCPY)
+#if !defined(__LZO_DOS16) && !defined(__LZO_WIN16)
+
+#define MEMCPY8_DS(dest,src,len) \
+    memcpy(dest,src,len); \
+    dest += len; \
+    src += len
+
+#endif
+#endif
+
+#if 0 && !defined(MEMCPY8_DS)
+
+#define MEMCPY8_DS(dest,src,len) \
+    { do { \
+	*dest++ = *src++; \
+	*dest++ = *src++; \
+	*dest++ = *src++; \
+	*dest++ = *src++; \
+	*dest++ = *src++; \
+	*dest++ = *src++; \
+	*dest++ = *src++; \
+	*dest++ = *src++; \
+	len -= 8; \
+    } while (len > 0); }
+
+#endif
+
+#if !defined(MEMCPY8_DS)
+
+#define MEMCPY8_DS(dest,src,len) \
+    { register lzo_uint __l = (len) / 8; \
+    do { \
+	*dest++ = *src++; \
+	*dest++ = *src++; \
+	*dest++ = *src++; \
+	*dest++ = *src++; \
+	*dest++ = *src++; \
+	*dest++ = *src++; \
+	*dest++ = *src++; \
+	*dest++ = *src++; \
+    } while (--__l > 0); }
+
+#endif
+
+#define MEMCPY_DS(dest,src,len) \
+    do *dest++ = *src++; \
+    while (--len > 0)
+
+#define MEMMOVE_DS(dest,src,len) \
+    do *dest++ = *src++; \
+    while (--len > 0)
+
+#if 0 && defined(LZO_OPTIMIZE_GNUC_i386)
+
+#define BZERO8_PTR(s,l,n) \
+__asm__ __volatile__( \
+    "movl  %0,%%eax \n"             \
+    "movl  %1,%%edi \n"             \
+    "movl  %2,%%ecx \n"             \
+    "cld \n"                        \
+    "rep \n"                        \
+    "stosl %%eax,(%%edi) \n"        \
+    :               \
+    :"g" (0),"g" (s),"g" (n)        \
+    :"eax","edi","ecx", "memory", "cc" \
+)
+
+#elif (LZO_UINT_MAX <= SIZE_T_MAX) && defined(HAVE_MEMSET)
+
+#define BZERO8_PTR(s,l,n) \
+    memset((lzo_voidp)(s),0,(lzo_uint)(l)*(n))
+
+#else
+
+#define BZERO8_PTR(s,l,n) \
+    lzo_memset((lzo_voidp)(s),0,(lzo_uint)(l)*(n))
+
+#endif
+
+#if 0
+#if defined(__GNUC__) && defined(__i386__)
+
+unsigned char lzo_rotr8(unsigned char value, int shift);
+extern __inline__ unsigned char lzo_rotr8(unsigned char value, int shift)
+{
+    unsigned char result;
+
+    __asm__ __volatile__ ("movb %b1, %b0; rorb %b2, %b0"
+			: "=a"(result) : "g"(value), "c"(shift));
+    return result;
+}
+
+unsigned short lzo_rotr16(unsigned short value, int shift);
+extern __inline__ unsigned short lzo_rotr16(unsigned short value, int shift)
+{
+    unsigned short result;
+
+    __asm__ __volatile__ ("movw %b1, %b0; rorw %b2, %b0"
+			: "=a"(result) : "g"(value), "c"(shift));
+    return result;
+}
+
+#endif
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+
+LZO_PUBLIC(lzo_bool)
+lzo_assert(int expr)
+{
+    return (expr) ? 1 : 0;
+}
+
+/* If you use the LZO library in a product, you *must* keep this
+ * copyright string in the executable of your product.
+ */
+
+const lzo_byte __lzo_copyright[] =
+    "\n\n\n"
+    "LZO real-time data compression library.\n"
+    "Copyright (C) 1996, 1997, 1998 Markus Franz Xaver Johannes Oberhumer\n"
+    "<markus.oberhumer@jk.uni-linz.ac.at>\n"
+    "http://wildsau.idv.uni-linz.ac.at/mfx/lzo.html\n"
+    "\n"
+    "LZO version: v" LZO_VERSION_STRING ", " LZO_VERSION_DATE "\n"
+    "LZO build date: " __DATE__ " " __TIME__ "\n\n"
+    "LZO special compilation options:\n"
+#ifdef __cplusplus
+    " __cplusplus\n"
+#endif
+#ifdef __pic__
+    " __pic__\n"
+#endif
+#ifdef __PIC__
+    " __PIC__\n"
+#endif
+#if (UINT_MAX < LZO_0xffffffffL)
+    " 16BIT\n"
+#endif
+#if defined(__LZO_STRICT_16BIT)
+    " __LZO_STRICT_16BIT\n"
+#endif
+#if (UINT_MAX > LZO_0xffffffffL)
+    " UINT_MAX=" _LZO_MEXPAND(UINT_MAX) "\n"
+#endif
+#if (ULONG_MAX > LZO_0xffffffffL)
+    " ULONG_MAX=" _LZO_MEXPAND(ULONG_MAX) "\n"
+#endif
+#if defined(LZO_BYTE_ORDER)
+    " LZO_BYTE_ORDER=" _LZO_MEXPAND(LZO_BYTE_ORDER) "\n"
+#endif
+#if defined(LZO_UNALIGNED_OK_2)
+    " LZO_UNALIGNED_OK_2\n"
+#endif
+#if defined(LZO_UNALIGNED_OK_4)
+    " LZO_UNALIGNED_OK_4\n"
+#endif
+#if defined(LZO_ALIGNED_OK_4)
+    " LZO_ALIGNED_OK_4\n"
+#endif
+#if defined(LZO_DICT_USE_PTR)
+    " LZO_DICT_USE_PTR\n"
+#endif
+#if defined(__LZO_QUERY_COMPRESS)
+    " __LZO_QUERY_COMPRESS\n"
+#endif
+#if defined(__LZO_QUERY_DECOMPRESS)
+    " __LZO_QUERY_DECOMPRESS\n"
+#endif
+#if defined(__LZO_IN_MINILZO)
+    " __LZO_IN_MINILZO\n"
+#endif
+    "\n\n"
+    "$Id: LZO " LZO_VERSION_STRING " built " __DATE__ " " __TIME__
+#if defined(__GNUC__) && defined(__VERSION__)
+    " by gcc " __VERSION__
+#elif defined(__BORLANDC__)
+    " by Borland C " _LZO_MEXPAND(__BORLANDC__)
+#elif defined(_MSC_VER)
+    " by Microsoft C " _LZO_MEXPAND(_MSC_VER)
+#elif defined(__PUREC__)
+    " by Pure C " _LZO_MEXPAND(__PUREC__)
+#elif defined(__SC__)
+    " by Symantec C " _LZO_MEXPAND(__SC__)
+#elif defined(__TURBOC__)
+    " by Turbo C " _LZO_MEXPAND(__TURBOC__)
+#elif defined(__WATCOMC__)
+    " by Watcom C " _LZO_MEXPAND(__WATCOMC__)
+#endif
+    " $\n"
+    "$Copyright: LZO (C) 1996, 1997, 1998 Markus Franz Xaver Johannes Oberhumer $\n";
+
+LZO_PUBLIC(const lzo_byte *)
+lzo_copyright(void)
+{
+    return __lzo_copyright;
+}
+
+LZO_PUBLIC(unsigned)
+lzo_version(void)
+{
+    return LZO_VERSION;
+}
+
+LZO_PUBLIC(const char *)
+lzo_version_string(void)
+{
+    return LZO_VERSION_STRING;
+}
+
+LZO_PUBLIC(const char *)
+lzo_version_date(void)
+{
+    return LZO_VERSION_DATE;
+}
+
+LZO_PUBLIC(const lzo_charp)
+_lzo_version_string(void)
+{
+    return LZO_VERSION_STRING;
+}
+
+LZO_PUBLIC(const lzo_charp)
+_lzo_version_date(void)
+{
+    return LZO_VERSION_DATE;
+}
+
+#define LZO_BASE 65521u
+#define LZO_NMAX 5552
+
+#define LZO_DO1(buf,i)  {s1 += buf[i]; s2 += s1;}
+#define LZO_DO2(buf,i)  LZO_DO1(buf,i); LZO_DO1(buf,i+1);
+#define LZO_DO4(buf,i)  LZO_DO2(buf,i); LZO_DO2(buf,i+2);
+#define LZO_DO8(buf,i)  LZO_DO4(buf,i); LZO_DO4(buf,i+4);
+#define LZO_DO16(buf,i) LZO_DO8(buf,i); LZO_DO8(buf,i+8);
+
+LZO_PUBLIC(lzo_uint32)
+lzo_adler32(lzo_uint32 adler, const lzo_byte *buf, lzo_uint len)
+{
+    lzo_uint32 s1 = adler & 0xffff;
+    lzo_uint32 s2 = (adler >> 16) & 0xffff;
+    int k;
+
+    if (buf == NULL)
+	return 1;
+
+    while (len > 0)
+    {
+	k = len < LZO_NMAX ? (int) len : LZO_NMAX;
+	len -= k;
+	if (k >= 16) do
+	{
+	    LZO_DO16(buf,0);
+	    buf += 16;
+	    k -= 16;
+	} while (k >= 16);
+	if (k != 0) do
+	{
+	    s1 += *buf++;
+	    s2 += s1;
+	} while (--k > 0);
+	s1 %= LZO_BASE;
+	s2 %= LZO_BASE;
+    }
+    return (s2 << 16) | s1;
+}
+
+LZO_PUBLIC(int)
+lzo_memcmp(const lzo_voidp s1, const lzo_voidp s2, lzo_uint len)
+{
+#if (LZO_UINT_MAX <= SIZE_T_MAX) && defined(HAVE_MEMCMP)
+    return memcmp(s1,s2,len);
+#else
+    const lzo_byte *p1 = (const lzo_byte *) s1;
+    const lzo_byte *p2 = (const lzo_byte *) s2;
+    int d;
+
+    if (len > 0) do
+    {
+	d = *p1 - *p2;
+	if (d != 0)
+	    return d;
+	p1++;
+	p2++;
+    }
+    while (--len > 0);
+    return 0;
+#endif
+}
+
+LZO_PUBLIC(lzo_voidp)
+lzo_memcpy(lzo_voidp dest, const lzo_voidp src, lzo_uint len)
+{
+#if (LZO_UINT_MAX <= SIZE_T_MAX) && defined(HAVE_MEMCPY)
+    return memcpy(dest,src,len);
+#else
+    lzo_byte *p1 = (lzo_byte *) dest;
+    const lzo_byte *p2 = (const lzo_byte *) src;
+
+    if (len <= 0 || p1 == p2)
+	return dest;
+    do
+	*p1++ = *p2++;
+    while (--len > 0);
+    return dest;
+#endif
+}
+
+LZO_PUBLIC(lzo_voidp)
+lzo_memmove(lzo_voidp dest, const lzo_voidp src, lzo_uint len)
+{
+#if (LZO_UINT_MAX <= SIZE_T_MAX) && defined(HAVE_MEMMOVE)
+    return memmove(dest,src,len);
+#else
+    lzo_byte *p1 = (lzo_byte *) dest;
+    const lzo_byte *p2 = (const lzo_byte *) src;
+
+    if (len <= 0 || p1 == p2)
+	return dest;
+
+    if (p1 < p2)
+    {
+	do
+	    *p1++ = *p2++;
+	while (--len > 0);
+    }
+    else
+    {
+	p1 += len;
+	p2 += len;
+	do
+	    *--p1 = *--p2;
+	while (--len > 0);
+    }
+    return dest;
+#endif
+}
+
+LZO_PUBLIC(lzo_voidp)
+lzo_memset(lzo_voidp s, int c, lzo_uint len)
+{
+#if (LZO_UINT_MAX <= SIZE_T_MAX) && defined(HAVE_MEMSET)
+    return memset(s,c,len);
+#else
+    lzo_byte *p = (lzo_byte *) s;
+
+    if (len > 0) do
+	*p++ = LZO_BYTE(c);
+    while (--len > 0);
+    return s;
+#endif
+}
+
+#include <stdio.h>
+
+#if 0
+#  define IS_SIGNED(type)       (((type) (1ul << (8 * sizeof(type) - 1))) < 0)
+#  define IS_UNSIGNED(type)     (((type) (1ul << (8 * sizeof(type) - 1))) > 0)
+#else
+#  define IS_SIGNED(type)       (((type) (-1)) < ((type) 0))
+#  define IS_UNSIGNED(type)     (((type) (-1)) > ((type) 0))
+#endif
+
+static lzo_bool schedule_insns_bug(void);
+static lzo_bool strength_reduce_bug(int *);
+
+#if 0 || defined(LZO_DEBUG)
+static lzo_bool __lzo_assert_fail(const char *s, unsigned line)
+{
+#if defined(__palmos__)
+    printf("LZO assertion failed in line %u: '%s'\n",line,s);
+#else
+    fprintf(stderr,"LZO assertion failed in line %u: '%s'\n",line,s);
+#endif
+    return 0;
+}
+#  define __lzo_assert(x)   ((x) ? 1 : __lzo_assert_fail(#x,__LINE__))
+#else
+#  define __lzo_assert(x)   ((x) ? 1 : 0)
+#endif
+
+static lzo_bool basic_integral_check(void)
+{
+    lzo_bool r = 1;
+    lzo_bool sanity;
+
+    r &= __lzo_assert(CHAR_BIT == 8);
+    r &= __lzo_assert(sizeof(char) == 1);
+    r &= __lzo_assert(sizeof(short) >= 2);
+    r &= __lzo_assert(sizeof(long) >= 4);
+    r &= __lzo_assert(sizeof(int) >= sizeof(short));
+    r &= __lzo_assert(sizeof(long) >= sizeof(int));
+
+    r &= __lzo_assert(sizeof(lzo_uint32) >= 4);
+    r &= __lzo_assert(sizeof(lzo_uint32) >= sizeof(unsigned));
+#if defined(__LZO_STRICT_16BIT)
+    r &= __lzo_assert(sizeof(lzo_uint) == 2);
+#else
+    r &= __lzo_assert(sizeof(lzo_uint) >= 4);
+    r &= __lzo_assert(sizeof(lzo_uint) >= sizeof(unsigned));
+#endif
+
+#if defined(SIZEOF_UNSIGNED)
+    r &= __lzo_assert(SIZEOF_UNSIGNED == sizeof(unsigned));
+#endif
+#if defined(SIZEOF_UNSIGNED_LONG)
+    r &= __lzo_assert(SIZEOF_UNSIGNED_LONG == sizeof(unsigned long));
+#endif
+#if defined(SIZEOF_UNSIGNED_SHORT)
+    r &= __lzo_assert(SIZEOF_UNSIGNED_SHORT == sizeof(unsigned short));
+#endif
+#if !defined(__LZO_IN_MINILZO)
+#if defined(SIZEOF_SIZE_T)
+    r &= __lzo_assert(SIZEOF_SIZE_T == sizeof(size_t));
+#endif
+#endif
+
+    sanity = IS_UNSIGNED(unsigned short) && IS_UNSIGNED(unsigned) &&
+	     IS_UNSIGNED(unsigned long) &&
+	     IS_SIGNED(short) && IS_SIGNED(int) && IS_SIGNED(long);
+    if (sanity)
+    {
+	r &= __lzo_assert(IS_UNSIGNED(lzo_uint32));
+	r &= __lzo_assert(IS_UNSIGNED(lzo_uint));
+	r &= __lzo_assert(IS_SIGNED(lzo_int32));
+	r &= __lzo_assert(IS_SIGNED(lzo_int));
+
+	r &= __lzo_assert(INT_MAX    == LZO_STYPE_MAX(sizeof(int)));
+	r &= __lzo_assert(UINT_MAX   == LZO_UTYPE_MAX(sizeof(unsigned)));
+	r &= __lzo_assert(LONG_MAX   == LZO_STYPE_MAX(sizeof(long)));
+	r &= __lzo_assert(ULONG_MAX  == LZO_UTYPE_MAX(sizeof(unsigned long)));
+	r &= __lzo_assert(SHRT_MAX   == LZO_STYPE_MAX(sizeof(short)));
+	r &= __lzo_assert(USHRT_MAX  == LZO_UTYPE_MAX(sizeof(unsigned short)));
+	r &= __lzo_assert(LZO_UINT32_MAX == LZO_UTYPE_MAX(sizeof(lzo_uint32)));
+	r &= __lzo_assert(LZO_UINT_MAX   == LZO_UTYPE_MAX(sizeof(lzo_uint)));
+#if !defined(__LZO_IN_MINILZO)
+	r &= __lzo_assert(SIZE_T_MAX     == LZO_UTYPE_MAX(sizeof(size_t)));
+#endif
+    }
+
+#if 0
+    r &= __lzo_assert(LZO_BYTE(257) == 1);
+    r &= __lzo_assert(LZO_USHORT(65537L) == 1);
+#endif
+
+    return r;
+}
+
+static lzo_bool basic_ptr_check(void)
+{
+    lzo_bool r = 1;
+    lzo_bool sanity;
+
+    r &= __lzo_assert(sizeof(char *) >= sizeof(int));
+    r &= __lzo_assert(sizeof(lzo_byte *) >= sizeof(char *));
+
+    r &= __lzo_assert(sizeof(lzo_voidp) == sizeof(lzo_byte *));
+    r &= __lzo_assert(sizeof(lzo_voidp) == sizeof(lzo_voidpp));
+    r &= __lzo_assert(sizeof(lzo_voidp) == sizeof(lzo_bytepp));
+    r &= __lzo_assert(sizeof(lzo_voidp) >= sizeof(lzo_uint));
+
+    r &= __lzo_assert(sizeof(lzo_ptr_t) == sizeof(lzo_voidp));
+    r &= __lzo_assert(sizeof(lzo_ptr_t) >= sizeof(lzo_uint));
+
+    r &= __lzo_assert(sizeof(lzo_ptrdiff_t) >= 4);
+    r &= __lzo_assert(sizeof(lzo_ptrdiff_t) >= sizeof(ptrdiff_t));
+
+#if defined(SIZEOF_CHAR_P)
+    r &= __lzo_assert(SIZEOF_CHAR_P == sizeof(char *));
+#endif
+#if defined(SIZEOF_PTRDIFF_T)
+    r &= __lzo_assert(SIZEOF_PTRDIFF_T == sizeof(ptrdiff_t));
+#endif
+
+    sanity = IS_UNSIGNED(unsigned short) && IS_UNSIGNED(unsigned) &&
+	     IS_UNSIGNED(unsigned long) &&
+	     IS_SIGNED(short) && IS_SIGNED(int) && IS_SIGNED(long);
+    if (sanity)
+    {
+	r &= __lzo_assert(IS_UNSIGNED(lzo_ptr_t));
+	r &= __lzo_assert(IS_UNSIGNED(lzo_moff_t));
+	r &= __lzo_assert(IS_SIGNED(lzo_ptrdiff_t));
+	r &= __lzo_assert(IS_SIGNED(lzo_sptr_t));
+    }
+
+    return r;
+}
+
+static lzo_bool ptr_check(void)
+{
+    lzo_bool r = 1;
+    int i;
+    char _wrkmem[10 * sizeof(lzo_byte *) + sizeof(lzo_align_t)];
+    lzo_byte *wrkmem;
+    const lzo_bytepp dict;
+    unsigned char x[4 * sizeof(lzo_align_t)];
+    long d;
+    lzo_align_t a;
+
+    for (i = 0; i < (int) sizeof(x); i++)
+	x[i] = LZO_BYTE(i);
+
+    wrkmem = (lzo_byte *) LZO_PTR_ALIGN_UP(_wrkmem,sizeof(lzo_align_t));
+    dict = (const lzo_bytepp) wrkmem;
+
+    d = (long) ((lzo_bytep) dict - (lzo_bytep) _wrkmem);
+    r &= __lzo_assert(d >= 0);
+    r &= __lzo_assert(d < (long) sizeof(lzo_align_t));
+
+    memset(&a,0xff,sizeof(a));
+    r &= __lzo_assert(a.a_ushort == USHRT_MAX);
+    r &= __lzo_assert(a.a_uint == UINT_MAX);
+    r &= __lzo_assert(a.a_ulong == ULONG_MAX);
+    r &= __lzo_assert(a.a_lzo_uint == LZO_UINT_MAX);
+
+    if (r == 1)
+    {
+	for (i = 0; i < 8; i++)
+	    r &= __lzo_assert((lzo_voidp) (&dict[i]) == (lzo_voidp) (&wrkmem[i * sizeof(lzo_byte *)]));
+    }
+
+    memset(&a,0,sizeof(a));
+    r &= __lzo_assert(a.a_charp == NULL);
+    r &= __lzo_assert(a.a_lzo_bytep == NULL);
+    r &= __lzo_assert(NULL == 0);
+    if (r == 1)
+    {
+	for (i = 0; i < 10; i++)
+	    dict[i] = wrkmem;
+	BZERO8_PTR(dict+1,sizeof(dict[0]),8);
+	r &= __lzo_assert(dict[0] == wrkmem);
+	for (i = 1; i < 9; i++)
+	    r &= __lzo_assert(dict[i] == NULL);
+	r &= __lzo_assert(dict[9] == wrkmem);
+    }
+
+    if (r == 1)
+    {
+	unsigned k = 1;
+	const unsigned n = (unsigned) sizeof(lzo_uint32);
+	lzo_byte *p0;
+	lzo_byte *p1;
+
+	k += __lzo_align_gap(&x[k],n);
+	p0 = (lzo_bytep) &x[k];
+#if defined(PTR_LINEAR)
+	r &= __lzo_assert((PTR_LINEAR(p0) & (n-1)) == 0);
+#else
+	r &= __lzo_assert(n == 4);
+	r &= __lzo_assert(PTR_ALIGNED_4(p0));
+#endif
+
+	r &= __lzo_assert(k >= 1);
+	p1 = (lzo_bytep) &x[1];
+	r &= __lzo_assert(PTR_GE(p0,p1));
+
+	r &= __lzo_assert(k < 1+n);
+	p1 = (lzo_bytep) &x[1+n];
+	r &= __lzo_assert(PTR_LT(p0,p1));
+
+	if (r == 1)
+	{
+	    lzo_uint32 v0 = * (lzo_uint32 *) &x[k];
+	    lzo_uint32 v1 = * (lzo_uint32 *) &x[k+n];
+
+	    r &= __lzo_assert(v0 > 0);
+	    r &= __lzo_assert(v1 > 0);
+	}
+    }
+
+    return r;
+}
+
+LZO_PUBLIC(int)
+_lzo_config_check(void)
+{
+    lzo_bool r = 1;
+    int i;
+    lzo_uint32 adler;
+    union {
+	lzo_uint32 a;
+	unsigned short b;
+	lzo_uint32 aa[4];
+	unsigned char x[4*sizeof(lzo_align_t)];
+    } u;
+
+#if 0
+    r &= __lzo_assert((const void *)&u == (const void *)&u.a);
+    r &= __lzo_assert((const void *)&u == (const void *)&u.b);
+    r &= __lzo_assert((const void *)&u == (const void *)&u.x[0]);
+    r &= __lzo_assert((const void *)&u == (const void *)&u.aa[0]);
+#endif
+
+    r &= basic_integral_check();
+    r &= basic_ptr_check();
+    if (r != 1)
+	return LZO_E_ERROR;
+
+    for (i = 0; i < (int) sizeof(u.x); i++)
+	u.x[i] = LZO_BYTE(i);
+
+#if 0
+    r &= __lzo_assert( (int) (unsigned char) ((char) -1) == 255);
+#endif
+
+#if defined(LZO_BYTE_ORDER)
+    if (r == 1)
+    {
+#  if (LZO_BYTE_ORDER == LZO_LITTLE_ENDIAN)
+	lzo_uint32 a = (lzo_uint32) (u.a & LZO_0xffffffffL);
+	unsigned short b = (unsigned short) (u.b & 0xffff);
+	r &= __lzo_assert(a == 0x03020100L);
+	r &= __lzo_assert(b == 0x0100);
+#  elif (LZO_BYTE_ORDER == LZO_BIG_ENDIAN)
+	lzo_uint32 a = u.a >> (8 * sizeof(u.a) - 32);
+	unsigned short b = u.b >> (8 * sizeof(u.b) - 16);
+	r &= __lzo_assert(a == 0x00010203L);
+	r &= __lzo_assert(b == 0x0001);
+#  else
+#    error invalid LZO_BYTE_ORDER
+#  endif
+    }
+#endif
+
+#if defined(LZO_UNALIGNED_OK_2)
+    r &= __lzo_assert(sizeof(short) == 2);
+    if (r == 1)
+    {
+	unsigned short b[4];
+
+	for (i = 0; i < 4; i++)
+	    b[i] = * (const unsigned short *) &u.x[i];
+
+#  if (LZO_BYTE_ORDER == LZO_LITTLE_ENDIAN)
+	r &= __lzo_assert(b[0] == 0x0100);
+	r &= __lzo_assert(b[1] == 0x0201);
+	r &= __lzo_assert(b[2] == 0x0302);
+	r &= __lzo_assert(b[3] == 0x0403);
+#  elif (LZO_BYTE_ORDER == LZO_BIG_ENDIAN)
+	r &= __lzo_assert(b[0] == 0x0001);
+	r &= __lzo_assert(b[1] == 0x0102);
+	r &= __lzo_assert(b[2] == 0x0203);
+	r &= __lzo_assert(b[3] == 0x0304);
+#  endif
+    }
+#endif
+
+#if defined(LZO_UNALIGNED_OK_4)
+    r &= __lzo_assert(sizeof(lzo_uint32) == 4);
+    if (r == 1)
+    {
+	lzo_uint32 a[4];
+
+	for (i = 0; i < 4; i++)
+	    a[i] = * (const lzo_uint32 *) &u.x[i];
+
+#  if (LZO_BYTE_ORDER == LZO_LITTLE_ENDIAN)
+	r &= __lzo_assert(a[0] == 0x03020100L);
+	r &= __lzo_assert(a[1] == 0x04030201L);
+	r &= __lzo_assert(a[2] == 0x05040302L);
+	r &= __lzo_assert(a[3] == 0x06050403L);
+#  elif (LZO_BYTE_ORDER == LZO_BIG_ENDIAN)
+	r &= __lzo_assert(a[0] == 0x00010203L);
+	r &= __lzo_assert(a[1] == 0x01020304L);
+	r &= __lzo_assert(a[2] == 0x02030405L);
+	r &= __lzo_assert(a[3] == 0x03040506L);
+#  endif
+    }
+#endif
+
+#if defined(LZO_ALIGNED_OK_4)
+    r &= __lzo_assert(sizeof(lzo_uint32) == 4);
+#endif
+
+    r &= __lzo_assert(lzo_sizeof_dict_t == sizeof(lzo_dict_t));
+
+    if (r == 1)
+    {
+	adler = lzo_adler32(0, NULL, 0);
+	adler = lzo_adler32(adler, lzo_copyright(), 200);
+	r &= __lzo_assert(adler == 0xfc1c43c4L);
+    }
+
+    if (r == 1)
+    {
+	r &= __lzo_assert(!schedule_insns_bug());
+    }
+
+    if (r == 1)
+    {
+	static int x[3];
+	static unsigned xn = 3;
+	register unsigned j;
+
+	for (j = 0; j < xn; j++)
+	    x[j] = (int)j - 3;
+	r &= __lzo_assert(!strength_reduce_bug(x));
+    }
+
+    if (r == 1)
+    {
+	r &= ptr_check();
+    }
+
+    return r == 1 ? LZO_E_OK : LZO_E_ERROR;
+}
+
+static lzo_bool schedule_insns_bug(void)
+{
+    const int clone[] = {1, 2, 0};
+    const int *q;
+    q = clone;
+    if (*q)
+	return 0;
+    return 1;
+}
+
+static lzo_bool strength_reduce_bug(int *x)
+{
+    return x[0] != -3 || x[1] != -2 || x[2] != -1;
+}
+
+int __lzo_init_done = 0;
+
+LZO_PUBLIC(int)
+__lzo_init2(unsigned v, int s1, int s2, int s3, int s4, int s5,
+			int s6, int s7, int s8, int s9)
+{
+    int r;
+
+    __lzo_init_done = 1;
+
+    if (v == 0)
+	return LZO_E_ERROR;
+
+    r = (s1 == -1 || s1 == (int) sizeof(short)) &&
+	(s2 == -1 || s2 == (int) sizeof(int)) &&
+	(s3 == -1 || s3 == (int) sizeof(long)) &&
+	(s4 == -1 || s4 == (int) sizeof(lzo_uint32)) &&
+	(s5 == -1 || s5 == (int) sizeof(lzo_uint)) &&
+	(s6 == -1 || s6 == (int) lzo_sizeof_dict_t) &&
+	(s7 == -1 || s7 == (int) sizeof(char *)) &&
+	(s8 == -1 || s8 == (int) sizeof(lzo_voidp)) &&
+	(s9 == -1 || s9 == (int) sizeof(lzo_compress_t));
+    if (!r)
+	return LZO_E_ERROR;
+
+    r = _lzo_config_check();
+    if (r != LZO_E_OK)
+	return r;
+
+    return r;
+}
+
+#if !defined(__LZO_IN_MINILZO)
+
+LZO_EXTERN(int)
+__lzo_init(unsigned v,int s1,int s2,int s3,int s4,int s5,int s6,int s7);
+
+LZO_PUBLIC(int)
+__lzo_init(unsigned v,int s1,int s2,int s3,int s4,int s5,int s6,int s7)
+{
+    if (v == 0 || v > 0x1010)
+	return LZO_E_ERROR;
+    return __lzo_init2(v,s1,s2,s3,s4,s5,-1,-1,s6,s7);
+}
+
+#endif
+
+#define do_compress         _lzo1x_1_do_compress
+
+#define LZO_NEED_DICT_H
+#define D_BITS          14
+#define D_INDEX1(d,p)       d = DM((0x21*DX3(p,5,5,6)) >> 5)
+#define D_INDEX2(d,p)       d = (d & (D_MASK & 0x7ff)) ^ (D_HIGH | 0x1f)
+
+#ifndef __LZO_CONFIG1X_H
+#define __LZO_CONFIG1X_H
+
+#if !defined(LZO1X) && !defined(LZO1Y) && !defined(LZO1Z)
+#  define LZO1X
+#endif
+
+#if !defined(__LZO_IN_MINILZO)
+#include <lzo1x.h>
+#endif
+
+#define LZO_EOF_CODE
+#undef LZO_DETERMINISTIC
+
+#define M1_MAX_OFFSET   0x0400
+#ifndef M2_MAX_OFFSET
+#define M2_MAX_OFFSET   0x0800
+#endif
+#define M3_MAX_OFFSET   0x4000
+#define M4_MAX_OFFSET   0xbfff
+
+#define MX_MAX_OFFSET   (M1_MAX_OFFSET + M2_MAX_OFFSET)
+
+#define M1_MIN_LEN      2
+#define M1_MAX_LEN      2
+#define M2_MIN_LEN      3
+#ifndef M2_MAX_LEN
+#define M2_MAX_LEN      8
+#endif
+#define M3_MIN_LEN      3
+#define M3_MAX_LEN      33
+#define M4_MIN_LEN      3
+#define M4_MAX_LEN      9
+
+#define M1_MARKER       0
+#define M2_MARKER       64
+#define M3_MARKER       32
+#define M4_MARKER       16
+
+#ifndef MIN_LOOKAHEAD
+#define MIN_LOOKAHEAD       (M2_MAX_LEN + 1)
+#endif
+
+#if defined(LZO_NEED_DICT_H)
+
+#ifndef LZO_HASH
+#define LZO_HASH            LZO_HASH_LZO_INCREMENTAL_B
+#endif
+#define DL_MIN_LEN          M2_MIN_LEN
+
+#ifndef __LZO_DICT_H
+#define __LZO_DICT_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if !defined(D_BITS) && defined(DBITS)
+#  define D_BITS        DBITS
+#endif
+#if !defined(D_BITS)
+#  error D_BITS is not defined
+#endif
+#if (D_BITS < 16)
+#  define D_SIZE        LZO_SIZE(D_BITS)
+#  define D_MASK        LZO_MASK(D_BITS)
+#else
+#  define D_SIZE        LZO_USIZE(D_BITS)
+#  define D_MASK        LZO_UMASK(D_BITS)
+#endif
+#define D_HIGH          ((D_MASK >> 1) + 1)
+
+#if !defined(DD_BITS)
+#  define DD_BITS       0
+#endif
+#define DD_SIZE         LZO_SIZE(DD_BITS)
+#define DD_MASK         LZO_MASK(DD_BITS)
+
+#if !defined(DL_BITS)
+#  define DL_BITS       (D_BITS - DD_BITS)
+#endif
+#if (DL_BITS < 16)
+#  define DL_SIZE       LZO_SIZE(DL_BITS)
+#  define DL_MASK       LZO_MASK(DL_BITS)
+#else
+#  define DL_SIZE       LZO_USIZE(DL_BITS)
+#  define DL_MASK       LZO_UMASK(DL_BITS)
+#endif
+
+#if (D_BITS != DL_BITS + DD_BITS)
+#  error D_BITS does not match
+#endif
+#if (D_BITS < 8 || D_BITS > 18)
+#  error invalid D_BITS
+#endif
+#if (DL_BITS < 8 || DL_BITS > 20)
+#  error invalid DL_BITS
+#endif
+#if (DD_BITS < 0 || DD_BITS > 6)
+#  error invalid DD_BITS
+#endif
+
+#if !defined(DL_MIN_LEN)
+#  define DL_MIN_LEN    3
+#endif
+#if !defined(DL_SHIFT)
+#  define DL_SHIFT      ((DL_BITS + (DL_MIN_LEN - 1)) / DL_MIN_LEN)
+#endif
+
+#define LZO_HASH_GZIP                   1
+#define LZO_HASH_GZIP_INCREMENTAL       2
+#define LZO_HASH_LZO_INCREMENTAL_A      3
+#define LZO_HASH_LZO_INCREMENTAL_B      4
+
+#if !defined(LZO_HASH)
+#  error choose a hashing strategy
+#endif
+
+#if (DL_MIN_LEN == 3)
+#  define _DV2_A(p,shift1,shift2) \
+	(((( (lzo_uint32)((p)[0]) << shift1) ^ (p)[1]) << shift2) ^ (p)[2])
+#  define _DV2_B(p,shift1,shift2) \
+	(((( (lzo_uint32)((p)[2]) << shift1) ^ (p)[1]) << shift2) ^ (p)[0])
+#  define _DV3_B(p,shift1,shift2,shift3) \
+	((_DV2_B((p)+1,shift1,shift2) << (shift3)) ^ (p)[0])
+#elif (DL_MIN_LEN == 2)
+#  define _DV2_A(p,shift1,shift2) \
+	(( (lzo_uint32)(p[0]) << shift1) ^ p[1])
+#  define _DV2_B(p,shift1,shift2) \
+	(( (lzo_uint32)(p[1]) << shift1) ^ p[2])
+#else
+#  error invalid DL_MIN_LEN
+#endif
+#define _DV_A(p,shift)      _DV2_A(p,shift,shift)
+#define _DV_B(p,shift)      _DV2_B(p,shift,shift)
+#define DA2(p,s1,s2) \
+	(((((lzo_uint32)((p)[2]) << (s2)) + (p)[1]) << (s1)) + (p)[0])
+#define DS2(p,s1,s2) \
+	(((((lzo_uint32)((p)[2]) << (s2)) - (p)[1]) << (s1)) - (p)[0])
+#define DX2(p,s1,s2) \
+	(((((lzo_uint32)((p)[2]) << (s2)) ^ (p)[1]) << (s1)) ^ (p)[0])
+#define DA3(p,s1,s2,s3) ((DA2((p)+1,s2,s3) << (s1)) + (p)[0])
+#define DS3(p,s1,s2,s3) ((DS2((p)+1,s2,s3) << (s1)) - (p)[0])
+#define DX3(p,s1,s2,s3) ((DX2((p)+1,s2,s3) << (s1)) ^ (p)[0])
+#define DMS(v,s)        ((lzo_uint) (((v) & (D_MASK >> (s))) << (s)))
+#define DM(v)           DMS(v,0)
+
+#if (LZO_HASH == LZO_HASH_GZIP)
+#  define _DINDEX(dv,p)     (_DV_A((p),DL_SHIFT))
+
+#elif (LZO_HASH == LZO_HASH_GZIP_INCREMENTAL)
+#  define __LZO_HASH_INCREMENTAL
+#  define DVAL_FIRST(dv,p)  dv = _DV_A((p),DL_SHIFT)
+#  define DVAL_NEXT(dv,p)   dv = (((dv) << DL_SHIFT) ^ p[2])
+#  define _DINDEX(dv,p)     (dv)
+#  define DVAL_LOOKAHEAD    DL_MIN_LEN
+
+#elif (LZO_HASH == LZO_HASH_LZO_INCREMENTAL_A)
+#  define __LZO_HASH_INCREMENTAL
+#  define DVAL_FIRST(dv,p)  dv = _DV_A((p),5)
+#  define DVAL_NEXT(dv,p) \
+		dv ^= (lzo_uint32)(p[-1]) << (2*5); dv = (((dv) << 5) ^ p[2])
+#  define _DINDEX(dv,p)     ((0x9f5f * (dv)) >> 5)
+#  define DVAL_LOOKAHEAD    DL_MIN_LEN
+
+#elif (LZO_HASH == LZO_HASH_LZO_INCREMENTAL_B)
+#  define __LZO_HASH_INCREMENTAL
+#  define DVAL_FIRST(dv,p)  dv = _DV_B((p),5)
+#  define DVAL_NEXT(dv,p) \
+		dv ^= p[-1]; dv = (((dv) >> 5) ^ ((lzo_uint32)(p[2]) << (2*5)))
+#  define _DINDEX(dv,p)     ((0x9f5f * (dv)) >> 5)
+#  define DVAL_LOOKAHEAD    DL_MIN_LEN
+
+#else
+#  error choose a hashing strategy
+#endif
+
+#ifndef DINDEX
+#define DINDEX(dv,p)        ((lzo_uint)((_DINDEX(dv,p)) & DL_MASK) << DD_BITS)
+#endif
+#if !defined(DINDEX1) && defined(D_INDEX1)
+#define DINDEX1             D_INDEX1
+#endif
+#if !defined(DINDEX2) && defined(D_INDEX2)
+#define DINDEX2             D_INDEX2
+#endif
+
+#if !defined(__LZO_HASH_INCREMENTAL)
+#  define DVAL_FIRST(dv,p)  ((void) 0)
+#  define DVAL_NEXT(dv,p)   ((void) 0)
+#  define DVAL_LOOKAHEAD    0
+#endif
+
+#if !defined(DVAL_ASSERT)
+#if defined(__LZO_HASH_INCREMENTAL) && !defined(NDEBUG)
+static void DVAL_ASSERT(lzo_uint32 dv, const lzo_byte *p)
+{
+    lzo_uint32 df;
+    DVAL_FIRST(df,(p));
+    assert(DINDEX(dv,p) == DINDEX(df,p));
+}
+#else
+#  define DVAL_ASSERT(dv,p) ((void) 0)
+#endif
+#endif
+
+#if defined(LZO_DICT_USE_PTR)
+#  define DENTRY(p,in)                          (p)
+#  define GINDEX(m_pos,m_off,dict,dindex,in)    m_pos = dict[dindex]
+#else
+#  define DENTRY(p,in)                          ((lzo_uint) ((p)-(in)))
+#  define GINDEX(m_pos,m_off,dict,dindex,in)    m_off = dict[dindex]
+#endif
+
+#if (DD_BITS == 0)
+
+#  define UPDATE_D(dict,drun,dv,p,in)       dict[ DINDEX(dv,p) ] = DENTRY(p,in)
+#  define UPDATE_I(dict,drun,index,p,in)    dict[index] = DENTRY(p,in)
+#  define UPDATE_P(ptr,drun,p,in)           (ptr)[0] = DENTRY(p,in)
+
+#else
+
+#  define UPDATE_D(dict,drun,dv,p,in)   \
+	dict[ DINDEX(dv,p) + drun++ ] = DENTRY(p,in); drun &= DD_MASK
+#  define UPDATE_I(dict,drun,index,p,in)    \
+	dict[ (index) + drun++ ] = DENTRY(p,in); drun &= DD_MASK
+#  define UPDATE_P(ptr,drun,p,in)   \
+	(ptr) [ drun++ ] = DENTRY(p,in); drun &= DD_MASK
+
+#endif
+
+#if defined(LZO_DICT_USE_PTR)
+
+#define LZO_CHECK_MPOS_DET(m_pos,m_off,in,ip,max_offset) \
+	(m_pos == NULL || (m_off = (lzo_moff_t) (ip - m_pos)) > max_offset)
+
+#define LZO_CHECK_MPOS_NON_DET(m_pos,m_off,in,ip,max_offset) \
+    (BOUNDS_CHECKING_OFF_IN_EXPR( \
+	(PTR_LT(m_pos,in) || \
+	 (m_off = (lzo_moff_t) PTR_DIFF(ip,m_pos)) <= 0 || \
+	  m_off > max_offset) ))
+
+#else
+
+#define LZO_CHECK_MPOS_DET(m_pos,m_off,in,ip,max_offset) \
+	(m_off == 0 || \
+	 ((m_off = (lzo_moff_t) ((ip)-(in)) - m_off) > max_offset) || \
+	 (m_pos = (ip) - (m_off), 0) )
+
+#define LZO_CHECK_MPOS_NON_DET(m_pos,m_off,in,ip,max_offset) \
+	((lzo_moff_t) ((ip)-(in)) <= m_off || \
+	 ((m_off = (lzo_moff_t) ((ip)-(in)) - m_off) > max_offset) || \
+	 (m_pos = (ip) - (m_off), 0) )
+
+#endif
+
+#if defined(LZO_DETERMINISTIC)
+#  define LZO_CHECK_MPOS    LZO_CHECK_MPOS_DET
+#else
+#  define LZO_CHECK_MPOS    LZO_CHECK_MPOS_NON_DET
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+
+#endif
+
+#endif
+
+#define DO_COMPRESS     lzo1x_1_compress
+
+static
+lzo_uint do_compress     ( const lzo_byte *in , lzo_uint  in_len,
+				 lzo_byte *out, lzo_uint *out_len,
+				 lzo_voidp wrkmem )
+{
+#if 0 && defined(__GNUC__) && defined(__i386__)
+    register const lzo_byte *ip __asm__("%esi");
+#else
+    register const lzo_byte *ip;
+#endif
+    lzo_byte *op;
+    const lzo_byte * const in_end = in + in_len;
+    const lzo_byte * const ip_end = in + in_len - M2_MAX_LEN - 5;
+    const lzo_byte *ii;
+    lzo_dict_p const dict = (lzo_dict_p) wrkmem;
+
+    op = out;
+    ip = in;
+    ii = ip;
+
+    ip += 4;
+    for (;;)
+    {
+#if 0 && defined(__GNUC__) && defined(__i386__)
+	register const lzo_byte *m_pos __asm__("%edi");
+#else
+	register const lzo_byte *m_pos;
+#endif
+	lzo_moff_t m_off;
+	lzo_uint m_len;
+	lzo_uint dindex;
+
+	DINDEX1(dindex,ip);
+	GINDEX(m_pos,m_off,dict,dindex,in);
+	if (LZO_CHECK_MPOS_NON_DET(m_pos,m_off,in,ip,M4_MAX_OFFSET))
+	    goto literal;
+#if 1
+	if (m_off <= M2_MAX_OFFSET || m_pos[3] == ip[3])
+	    goto try_match;
+	DINDEX2(dindex,ip);
+#endif
+	GINDEX(m_pos,m_off,dict,dindex,in);
+	if (LZO_CHECK_MPOS_NON_DET(m_pos,m_off,in,ip,M4_MAX_OFFSET))
+	    goto literal;
+	if (m_off <= M2_MAX_OFFSET || m_pos[3] == ip[3])
+	    goto try_match;
+	goto literal;
+
+try_match:
+#if 1 && defined(LZO_UNALIGNED_OK_2)
+	if (* (const lzo_ushortp) m_pos != * (const lzo_ushortp) ip)
+#else
+	if (m_pos[0] != ip[0] || m_pos[1] != ip[1])
+#endif
+	{
+	}
+	else
+	{
+	    if (m_pos[2] == ip[2])
+	    {
+#if 0
+		if (m_off <= M2_MAX_OFFSET)
+		    goto match;
+		if (lit <= 3)
+		    goto match;
+		if (lit == 3)
+		{
+		    assert(op - 2 > out); op[-2] |= LZO_BYTE(3);
+		    *op++ = *ii++; *op++ = *ii++; *op++ = *ii++;
+		    goto code_match;
+		}
+		if (m_pos[3] == ip[3])
+#endif
+		    goto match;
+	    }
+	    else
+	    {
+#if 0
+#if 0
+		if (m_off <= M1_MAX_OFFSET && lit > 0 && lit <= 3)
+#else
+		if (m_off <= M1_MAX_OFFSET && lit == 3)
+#endif
+		{
+		    register lzo_uint t;
+
+		    t = lit;
+		    assert(op - 2 > out); op[-2] |= LZO_BYTE(t);
+		    do *op++ = *ii++; while (--t > 0);
+		    assert(ii == ip);
+		    m_off -= 1;
+		    *op++ = LZO_BYTE(M1_MARKER | ((m_off & 3) << 2));
+		    *op++ = LZO_BYTE(m_off >> 2);
+		    ip += 2;
+		    goto match_done;
+		}
+#endif
+	    }
+	}
+
+literal:
+	UPDATE_I(dict,0,dindex,ip,in);
+	++ip;
+	if (ip >= ip_end)
+	    break;
+	continue;
+
+match:
+	UPDATE_I(dict,0,dindex,ip,in);
+	if (ip - ii > 0)
+	{
+	    register lzo_uint t = ip - ii;
+
+	    if (t <= 3)
+	    {
+		assert(op - 2 > out);
+		op[-2] |= LZO_BYTE(t);
+	    }
+	    else if (t <= 18)
+		*op++ = LZO_BYTE(t - 3);
+	    else
+	    {
+		register lzo_uint tt = t - 18;
+
+		*op++ = 0;
+		while (tt > 255)
+		{
+		    tt -= 255;
+		    *op++ = 0;
+		}
+		assert(tt > 0);
+		*op++ = LZO_BYTE(tt);
+	    }
+	    do *op++ = *ii++; while (--t > 0);
+	}
+
+	assert(ii == ip);
+	ip += 3;
+	if (m_pos[3] != *ip++ || m_pos[4] != *ip++ || m_pos[5] != *ip++ ||
+	    m_pos[6] != *ip++ || m_pos[7] != *ip++ || m_pos[8] != *ip++
+#ifdef LZO1Y
+	    || m_pos[ 9] != *ip++ || m_pos[10] != *ip++ || m_pos[11] != *ip++
+	    || m_pos[12] != *ip++ || m_pos[13] != *ip++ || m_pos[14] != *ip++
+#endif
+	   )
+	{
+	    --ip;
+	    m_len = ip - ii;
+	    assert(m_len >= 3); assert(m_len <= M2_MAX_LEN);
+
+	    if (m_off <= M2_MAX_OFFSET)
+	    {
+		m_off -= 1;
+#if defined(LZO1X)
+		*op++ = LZO_BYTE(((m_len - 1) << 5) | ((m_off & 7) << 2));
+		*op++ = LZO_BYTE(m_off >> 3);
+#elif defined(LZO1Y)
+		*op++ = LZO_BYTE(((m_len + 1) << 4) | ((m_off & 3) << 2));
+		*op++ = LZO_BYTE(m_off >> 2);
+#endif
+	    }
+	    else if (m_off <= M3_MAX_OFFSET)
+	    {
+		m_off -= 1;
+		*op++ = LZO_BYTE(M3_MARKER | (m_len - 2));
+		goto m3_m4_offset;
+	    }
+	    else
+#if defined(LZO1X)
+	    {
+		m_off -= 0x4000;
+		assert(m_off > 0); assert(m_off <= 0x7fff);
+		*op++ = LZO_BYTE(M4_MARKER |
+				 ((m_off & 0x4000) >> 11) | (m_len - 2));
+		goto m3_m4_offset;
+	    }
+#elif defined(LZO1Y)
+		goto m4_match;
+#endif
+	}
+	else
+	{
+	    {
+		const lzo_byte *end = in_end;
+		const lzo_byte *m = m_pos + M2_MAX_LEN + 1;
+		while (ip < end && *m == *ip)
+		    m++, ip++;
+		m_len = (ip - ii);
+	    }
+	    assert(m_len > M2_MAX_LEN);
+
+	    if (m_off <= M3_MAX_OFFSET)
+	    {
+		m_off -= 1;
+		if (m_len <= 33)
+		    *op++ = LZO_BYTE(M3_MARKER | (m_len - 2));
+		else
+		{
+		    m_len -= 33;
+		    *op++ = M3_MARKER | 0;
+		    goto m3_m4_len;
+		}
+	    }
+	    else
+	    {
+#if defined(LZO1Y)
+m4_match:
+#endif
+		m_off -= 0x4000;
+		assert(m_off > 0); assert(m_off <= 0x7fff);
+		if (m_len <= M4_MAX_LEN)
+		    *op++ = LZO_BYTE(M4_MARKER |
+				     ((m_off & 0x4000) >> 11) | (m_len - 2));
+		else
+		{
+		    m_len -= M4_MAX_LEN;
+		    *op++ = LZO_BYTE(M4_MARKER | ((m_off & 0x4000) >> 11));
+m3_m4_len:
+		    while (m_len > 255)
+		    {
+			m_len -= 255;
+			*op++ = 0;
+		    }
+		    assert(m_len > 0);
+		    *op++ = LZO_BYTE(m_len);
+		}
+	    }
+
+m3_m4_offset:
+	    *op++ = LZO_BYTE((m_off & 63) << 2);
+	    *op++ = LZO_BYTE(m_off >> 6);
+	}
+
+#if 0
+match_done:
+#endif
+	ii = ip;
+	if (ip >= ip_end)
+	    break;
+    }
+
+    *out_len = op - out;
+    return (lzo_uint) (in_end - ii);
+}
+
+LZO_PUBLIC(int)
+DO_COMPRESS      ( const lzo_byte *in , lzo_uint  in_len,
+			 lzo_byte *out, lzo_uint *out_len,
+			 lzo_voidp wrkmem )
+{
+    lzo_byte *op = out;
+    lzo_uint t;
+
+#if defined(__LZO_QUERY_COMPRESS)
+    if (__LZO_IS_COMPRESS_QUERY(in,in_len,out,out_len,wrkmem))
+	return __LZO_QUERY_COMPRESS(in,in_len,out,out_len,wrkmem,D_SIZE,lzo_sizeof(lzo_dict_t));
+#endif
+
+    if (in_len <= M2_MAX_LEN + 5)
+	t = in_len;
+    else
+    {
+	t = do_compress(in,in_len,op,out_len,wrkmem);
+	op += *out_len;
+    }
+
+    if (t > 0)
+    {
+	const lzo_byte *ii = in + in_len - t;
+
+	if (op == out && t <= 238)
+	    *op++ = LZO_BYTE(17 + t);
+	else if (t <= 3)
+	    op[-2] |= LZO_BYTE(t);
+	else if (t <= 18)
+	    *op++ = LZO_BYTE(t - 3);
+	else
+	{
+	    lzo_uint tt = t - 18;
+
+	    *op++ = 0;
+	    while (tt > 255)
+	    {
+		tt -= 255;
+		*op++ = 0;
+	    }
+	    assert(tt > 0);
+	    *op++ = LZO_BYTE(tt);
+	}
+	do *op++ = *ii++; while (--t > 0);
+    }
+
+    *op++ = M4_MARKER | 1;
+    *op++ = 0;
+    *op++ = 0;
+
+    *out_len = op - out;
+    return LZO_E_OK;
+}
+
+#undef do_compress
+#undef DO_COMPRESS
+#undef LZO_HASH
+
+#undef LZO_TEST_DECOMPRESS_OVERRUN
+#undef LZO_TEST_DECOMPRESS_OVERRUN_INPUT
+#undef LZO_TEST_DECOMPRESS_OVERRUN_OUTPUT
+#undef LZO_TEST_DECOMPRESS_OVERRUN_LOOKBEHIND
+#undef DO_DECOMPRESS
+#define DO_DECOMPRESS       lzo1x_decompress
+
+#if defined(LZO_TEST_DECOMPRESS_OVERRUN)
+#  if !defined(LZO_TEST_DECOMPRESS_OVERRUN_INPUT)
+#    define LZO_TEST_DECOMPRESS_OVERRUN_INPUT       2
+#  endif
+#  if !defined(LZO_TEST_DECOMPRESS_OVERRUN_OUTPUT)
+#    define LZO_TEST_DECOMPRESS_OVERRUN_OUTPUT      2
+#  endif
+#  if !defined(LZO_TEST_DECOMPRESS_OVERRUN_LOOKBEHIND)
+#    define LZO_TEST_DECOMPRESS_OVERRUN_LOOKBEHIND
+#  endif
+#endif
+
+#undef TEST_IP
+#undef TEST_OP
+#undef TEST_LOOKBEHIND
+#undef NEED_IP
+#undef NEED_OP
+#undef HAVE_TEST_IP
+#undef HAVE_TEST_OP
+#undef HAVE_NEED_IP
+#undef HAVE_NEED_OP
+#undef HAVE_ANY_IP
+#undef HAVE_ANY_OP
+
+#if defined(LZO_TEST_DECOMPRESS_OVERRUN_INPUT)
+#  if (LZO_TEST_DECOMPRESS_OVERRUN_INPUT >= 1)
+#    define TEST_IP             (ip < ip_end)
+#  endif
+#  if (LZO_TEST_DECOMPRESS_OVERRUN_INPUT >= 2)
+#    define NEED_IP(x) \
+	    if ((lzo_uint)(ip_end - ip) < (lzo_uint)(x))  goto input_overrun
+#  endif
+#endif
+
+#if defined(LZO_TEST_DECOMPRESS_OVERRUN_OUTPUT)
+#  if (LZO_TEST_DECOMPRESS_OVERRUN_OUTPUT >= 1)
+#    define TEST_OP             (op <= op_end)
+#  endif
+#  if (LZO_TEST_DECOMPRESS_OVERRUN_OUTPUT >= 2)
+#    undef TEST_OP
+#    define NEED_OP(x) \
+	    if ((lzo_uint)(op_end - op) < (lzo_uint)(x))  goto output_overrun
+#  endif
+#endif
+
+#if defined(LZO_TEST_DECOMPRESS_OVERRUN_LOOKBEHIND)
+#  define TEST_LOOKBEHIND(m_pos,out)    if (m_pos < out) goto lookbehind_overrun
+#else
+#  define TEST_LOOKBEHIND(m_pos,op)     ((void) 0)
+#endif
+
+#if !defined(LZO_EOF_CODE) && !defined(TEST_IP)
+#  define TEST_IP               (ip < ip_end)
+#endif
+
+#if defined(TEST_IP)
+#  define HAVE_TEST_IP
+#else
+#  define TEST_IP               1
+#endif
+#if defined(TEST_OP)
+#  define HAVE_TEST_OP
+#else
+#  define TEST_OP               1
+#endif
+
+#if defined(NEED_IP)
+#  define HAVE_NEED_IP
+#else
+#  define NEED_IP(x)            ((void) 0)
+#endif
+#if defined(NEED_OP)
+#  define HAVE_NEED_OP
+#else
+#  define NEED_OP(x)            ((void) 0)
+#endif
+
+#if defined(HAVE_TEST_IP) || defined(HAVE_NEED_IP)
+#  define HAVE_ANY_IP
+#endif
+#if defined(HAVE_TEST_OP) || defined(HAVE_NEED_OP)
+#  define HAVE_ANY_OP
+#endif
+
+#if defined(DO_DECOMPRESS)
+LZO_PUBLIC(int)
+DO_DECOMPRESS  ( const lzo_byte *in , lzo_uint  in_len,
+		       lzo_byte *out, lzo_uint *out_len,
+		       lzo_voidp wrkmem )
+#endif
+{
+    register lzo_byte *op;
+    register const lzo_byte *ip;
+    register lzo_uint t;
+#if defined(COPY_DICT)
+    lzo_uint m_off;
+    const lzo_byte *dict_end;
+#else
+    register const lzo_byte *m_pos;
+#endif
+
+    const lzo_byte * const ip_end = in + in_len;
+#if defined(HAVE_ANY_OP)
+    lzo_byte * const op_end = out + *out_len;
+#endif
+#if defined(LZO1Z)
+    lzo_uint last_m_off = 0;
+#endif
+
+    LZO_UNUSED(wrkmem);
+
+#if defined(__LZO_QUERY_DECOMPRESS)
+    if (__LZO_IS_DECOMPRESS_QUERY(in,in_len,out,out_len,wrkmem))
+	return __LZO_QUERY_DECOMPRESS(in,in_len,out,out_len,wrkmem,0,0);
+#endif
+
+#if defined(COPY_DICT)
+    if (dict)
+    {
+	if (dict_len > M4_MAX_OFFSET)
+	{
+	    dict += dict_len - M4_MAX_OFFSET;
+	    dict_len = M4_MAX_OFFSET;
+	}
+	dict_end = dict + dict_len;
+    }
+    else
+    {
+	dict_len = 0;
+	dict_end = NULL;
+    }
+#endif
+
+    *out_len = 0;
+
+    op = out;
+    ip = in;
+
+    if (*ip > 17)
+    {
+	t = *ip++ - 17;
+	if (t < 4)
+	    goto match_next;
+	assert(t > 0); NEED_OP(t); NEED_IP(t+1);
+	do *op++ = *ip++; while (--t > 0);
+	goto first_literal_run;
+    }
+
+    while (TEST_IP && TEST_OP)
+    {
+	t = *ip++;
+	if (t >= 16)
+	    goto match;
+	if (t == 0)
+	{
+	    NEED_IP(1);
+	    while (*ip == 0)
+	    {
+		t += 255;
+		ip++;
+		NEED_IP(1);
+	    }
+	    t += 15 + *ip++;
+	}
+	assert(t > 0); NEED_OP(t+3); NEED_IP(t+4);
+#if defined(LZO_UNALIGNED_OK_4) || defined(LZO_ALIGNED_OK_4)
+#if !defined(LZO_UNALIGNED_OK_4)
+	if (PTR_ALIGNED2_4(op,ip))
+	{
+#endif
+	* (lzo_uint32p) op = * (const lzo_uint32p) ip;
+	op += 4; ip += 4;
+	if (--t > 0)
+	{
+	    if (t >= 4)
+	    {
+		do {
+		    * (lzo_uint32p) op = * (const lzo_uint32p) ip;
+		    op += 4; ip += 4; t -= 4;
+		} while (t >= 4);
+		if (t > 0) do *op++ = *ip++; while (--t > 0);
+	    }
+	    else
+		do *op++ = *ip++; while (--t > 0);
+	}
+#if !defined(LZO_UNALIGNED_OK_4)
+	}
+	else
+#endif
+#endif
+#if !defined(LZO_UNALIGNED_OK_4)
+	{
+	    *op++ = *ip++; *op++ = *ip++; *op++ = *ip++;
+	    do *op++ = *ip++; while (--t > 0);
+	}
+#endif
+
+first_literal_run:
+
+	t = *ip++;
+	if (t >= 16)
+	    goto match;
+#if defined(COPY_DICT)
+#if defined(LZO1Z)
+	m_off = (1 + M2_MAX_OFFSET) + (t << 6) + (*ip++ >> 2);
+	last_m_off = m_off;
+#else
+	m_off = (1 + M2_MAX_OFFSET) + (t >> 2) + (*ip++ << 2);
+#endif
+	NEED_OP(3);
+	t = 3; COPY_DICT(t,m_off)
+#else
+#if defined(LZO1Z)
+	t = (1 + M2_MAX_OFFSET) + (t << 6) + (*ip++ >> 2);
+	m_pos = op - t;
+	last_m_off = t;
+#else
+	m_pos = op - (1 + M2_MAX_OFFSET);
+	m_pos -= t >> 2;
+	m_pos -= *ip++ << 2;
+#endif
+	TEST_LOOKBEHIND(m_pos,out); NEED_OP(3);
+	*op++ = *m_pos++; *op++ = *m_pos++; *op++ = *m_pos;
+#endif
+	goto match_done;
+
+	while (TEST_IP && TEST_OP)
+	{
+match:
+	    if (t >= 64)
+	    {
+#if defined(COPY_DICT)
+#if defined(LZO1X)
+		m_off = 1 + ((t >> 2) & 7) + (*ip++ << 3);
+		t = (t >> 5) - 1;
+#elif defined(LZO1Y)
+		m_off = 1 + ((t >> 2) & 3) + (*ip++ << 2);
+		t = (t >> 4) - 3;
+#elif defined(LZO1Z)
+		m_off = t & 0x1f;
+		if (m_off >= 0x1c)
+		    m_off = last_m_off;
+		else
+		{
+		    m_off = 1 + (m_off << 6) + (*ip++ >> 2);
+		    last_m_off = m_off;
+		}
+		t = (t >> 5) - 1;
+#endif
+#else
+#if defined(LZO1X)
+		m_pos = op - 1;
+		m_pos -= (t >> 2) & 7;
+		m_pos -= *ip++ << 3;
+		t = (t >> 5) - 1;
+#elif defined(LZO1Y)
+		m_pos = op - 1;
+		m_pos -= (t >> 2) & 3;
+		m_pos -= *ip++ << 2;
+		t = (t >> 4) - 3;
+#elif defined(LZO1Z)
+		{
+		    lzo_uint off = t & 0x1f;
+		    m_pos = op;
+		    if (off >= 0x1c)
+		    {
+			assert(last_m_off > 0);
+			m_pos -= last_m_off;
+		    }
+		    else
+		    {
+			off = 1 + (off << 6) + (*ip++ >> 2);
+			m_pos -= off;
+			last_m_off = off;
+		    }
+		}
+		t = (t >> 5) - 1;
+#endif
+		TEST_LOOKBEHIND(m_pos,out); assert(t > 0); NEED_OP(t+3-1);
+		goto copy_match;
+#endif
+	    }
+	    else if (t >= 32)
+	    {
+		t &= 31;
+		if (t == 0)
+		{
+		    NEED_IP(1);
+		    while (*ip == 0)
+		    {
+			t += 255;
+			ip++;
+			NEED_IP(1);
+		    }
+		    t += 31 + *ip++;
+		}
+#if defined(COPY_DICT)
+#if defined(LZO1Z)
+		m_off = 1 + (ip[0] << 6) + (ip[1] >> 2);
+		last_m_off = m_off;
+#else
+		m_off = 1 + (ip[0] >> 2) + (ip[1] << 6);
+#endif
+#else
+#if defined(LZO1Z)
+		{
+		    lzo_uint off = 1 + (ip[0] << 6) + (ip[1] >> 2);
+		    m_pos = op - off;
+		    last_m_off = off;
+		}
+#elif defined(LZO_UNALIGNED_OK_2) && (LZO_BYTE_ORDER == LZO_LITTLE_ENDIAN)
+		m_pos = op - 1;
+		m_pos -= (* (const lzo_ushortp) ip) >> 2;
+#else
+		m_pos = op - 1;
+		m_pos -= (ip[0] >> 2) + (ip[1] << 6);
+#endif
+#endif
+		ip += 2;
+	    }
+	    else if (t >= 16)
+	    {
+#if defined(COPY_DICT)
+		m_off = (t & 8) << 11;
+#else
+		m_pos = op;
+		m_pos -= (t & 8) << 11;
+#endif
+		t &= 7;
+		if (t == 0)
+		{
+		    NEED_IP(1);
+		    while (*ip == 0)
+		    {
+			t += 255;
+			ip++;
+			NEED_IP(1);
+		    }
+		    t += 7 + *ip++;
+		}
+#if defined(COPY_DICT)
+#if defined(LZO1Z)
+		m_off += (ip[0] << 6) + (ip[1] >> 2);
+#else
+		m_off += (ip[0] >> 2) + (ip[1] << 6);
+#endif
+		ip += 2;
+		if (m_off == 0)
+		    goto eof_found;
+		m_off += 0x4000;
+#if defined(LZO1Z)
+		last_m_off = m_off;
+#endif
+#else
+#if defined(LZO1Z)
+		m_pos -= (ip[0] << 6) + (ip[1] >> 2);
+#elif defined(LZO_UNALIGNED_OK_2) && (LZO_BYTE_ORDER == LZO_LITTLE_ENDIAN)
+		m_pos -= (* (const lzo_ushortp) ip) >> 2;
+#else
+		m_pos -= (ip[0] >> 2) + (ip[1] << 6);
+#endif
+		ip += 2;
+		if (m_pos == op)
+		    goto eof_found;
+		m_pos -= 0x4000;
+#if defined(LZO1Z)
+		last_m_off = op - m_pos;
+#endif
+#endif
+	    }
+	    else
+	    {
+#if defined(COPY_DICT)
+#if defined(LZO1Z)
+		m_off = 1 + (t << 6) + (*ip++ >> 2);
+		last_m_off = m_off;
+#else
+		m_off = 1 + (t >> 2) + (*ip++ << 2);
+#endif
+		NEED_OP(2);
+		t = 2; COPY_DICT(t,m_off)
+#else
+#if defined(LZO1Z)
+		t = 1 + (t << 6) + (*ip++ >> 2);
+		m_pos = op - t;
+		last_m_off = t;
+#else
+		m_pos = op - 1;
+		m_pos -= t >> 2;
+		m_pos -= *ip++ << 2;
+#endif
+		TEST_LOOKBEHIND(m_pos,out); NEED_OP(2);
+		*op++ = *m_pos++; *op++ = *m_pos;
+#endif
+		goto match_done;
+	    }
+
+#if defined(COPY_DICT)
+
+	    NEED_OP(t+3-1);
+	    t += 3-1; COPY_DICT(t,m_off)
+
+#else
+
+	    TEST_LOOKBEHIND(m_pos,out); assert(t > 0); NEED_OP(t+3-1);
+#if defined(LZO_UNALIGNED_OK_4) || defined(LZO_ALIGNED_OK_4)
+#if !defined(LZO_UNALIGNED_OK_4)
+	    if (t >= 2 * 4 - (3 - 1) && PTR_ALIGNED2_4(op,m_pos))
+	    {
+		assert((op - m_pos) >= 4);
+#else
+	    if (t >= 2 * 4 - (3 - 1) && (op - m_pos) >= 4)
+	    {
+#endif
+		* (lzo_uint32p) op = * (const lzo_uint32p) m_pos;
+		op += 4; m_pos += 4; t -= 4 - (3 - 1);
+		do {
+		    * (lzo_uint32p) op = * (const lzo_uint32p) m_pos;
+		    op += 4; m_pos += 4; t -= 4;
+		} while (t >= 4);
+		if (t > 0) do *op++ = *m_pos++; while (--t > 0);
+	    }
+	    else
+#endif
+	    {
+copy_match:
+		*op++ = *m_pos++; *op++ = *m_pos++;
+		do *op++ = *m_pos++; while (--t > 0);
+	    }
+
+#endif
+
+match_done:
+#if defined(LZO1Z)
+	    t = ip[-1] & 3;
+#else
+	    t = ip[-2] & 3;
+#endif
+	    if (t == 0)
+		break;
+
+match_next:
+	    assert(t > 0); NEED_OP(t); NEED_IP(t+1);
+	    do *op++ = *ip++; while (--t > 0);
+	    t = *ip++;
+	}
+    }
+
+#if defined(HAVE_TEST_IP) || defined(HAVE_TEST_OP)
+    *out_len = op - out;
+    return LZO_E_EOF_NOT_FOUND;
+#endif
+
+eof_found:
+    assert(t == 1);
+    *out_len = op - out;
+    return (ip == ip_end ? LZO_E_OK :
+	   (ip < ip_end  ? LZO_E_INPUT_NOT_CONSUMED : LZO_E_INPUT_OVERRUN));
+
+#if defined(HAVE_NEED_IP)
+input_overrun:
+    *out_len = op - out;
+    return LZO_E_INPUT_OVERRUN;
+#endif
+
+#if defined(HAVE_NEED_OP)
+output_overrun:
+    *out_len = op - out;
+    return LZO_E_OUTPUT_OVERRUN;
+#endif
+
+#if defined(LZO_TEST_DECOMPRESS_OVERRUN_LOOKBEHIND)
+lookbehind_overrun:
+    *out_len = op - out;
+    return LZO_E_LOOKBEHIND_OVERRUN;
+#endif
+}
+
+#define LZO_TEST_DECOMPRESS_OVERRUN
+#undef DO_DECOMPRESS
+#define DO_DECOMPRESS       lzo1x_decompress_safe
+
+#if defined(LZO_TEST_DECOMPRESS_OVERRUN)
+#  if !defined(LZO_TEST_DECOMPRESS_OVERRUN_INPUT)
+#    define LZO_TEST_DECOMPRESS_OVERRUN_INPUT       2
+#  endif
+#  if !defined(LZO_TEST_DECOMPRESS_OVERRUN_OUTPUT)
+#    define LZO_TEST_DECOMPRESS_OVERRUN_OUTPUT      2
+#  endif
+#  if !defined(LZO_TEST_DECOMPRESS_OVERRUN_LOOKBEHIND)
+#    define LZO_TEST_DECOMPRESS_OVERRUN_LOOKBEHIND
+#  endif
+#endif
+
+#undef TEST_IP
+#undef TEST_OP
+#undef TEST_LOOKBEHIND
+#undef NEED_IP
+#undef NEED_OP
+#undef HAVE_TEST_IP
+#undef HAVE_TEST_OP
+#undef HAVE_NEED_IP
+#undef HAVE_NEED_OP
+#undef HAVE_ANY_IP
+#undef HAVE_ANY_OP
+
+#if defined(LZO_TEST_DECOMPRESS_OVERRUN_INPUT)
+#  if (LZO_TEST_DECOMPRESS_OVERRUN_INPUT >= 1)
+#    define TEST_IP             (ip < ip_end)
+#  endif
+#  if (LZO_TEST_DECOMPRESS_OVERRUN_INPUT >= 2)
+#    define NEED_IP(x) \
+	    if ((lzo_uint)(ip_end - ip) < (lzo_uint)(x))  goto input_overrun
+#  endif
+#endif
+
+#if defined(LZO_TEST_DECOMPRESS_OVERRUN_OUTPUT)
+#  if (LZO_TEST_DECOMPRESS_OVERRUN_OUTPUT >= 1)
+#    define TEST_OP             (op <= op_end)
+#  endif
+#  if (LZO_TEST_DECOMPRESS_OVERRUN_OUTPUT >= 2)
+#    undef TEST_OP
+#    define NEED_OP(x) \
+	    if ((lzo_uint)(op_end - op) < (lzo_uint)(x))  goto output_overrun
+#  endif
+#endif
+
+#if defined(LZO_TEST_DECOMPRESS_OVERRUN_LOOKBEHIND)
+#  define TEST_LOOKBEHIND(m_pos,out)    if (m_pos < out) goto lookbehind_overrun
+#else
+#  define TEST_LOOKBEHIND(m_pos,op)     ((void) 0)
+#endif
+
+#if !defined(LZO_EOF_CODE) && !defined(TEST_IP)
+#  define TEST_IP               (ip < ip_end)
+#endif
+
+#if defined(TEST_IP)
+#  define HAVE_TEST_IP
+#else
+#  define TEST_IP               1
+#endif
+#if defined(TEST_OP)
+#  define HAVE_TEST_OP
+#else
+#  define TEST_OP               1
+#endif
+
+#if defined(NEED_IP)
+#  define HAVE_NEED_IP
+#else
+#  define NEED_IP(x)            ((void) 0)
+#endif
+#if defined(NEED_OP)
+#  define HAVE_NEED_OP
+#else
+#  define NEED_OP(x)            ((void) 0)
+#endif
+
+#if defined(HAVE_TEST_IP) || defined(HAVE_NEED_IP)
+#  define HAVE_ANY_IP
+#endif
+#if defined(HAVE_TEST_OP) || defined(HAVE_NEED_OP)
+#  define HAVE_ANY_OP
+#endif
+
+#if defined(DO_DECOMPRESS)
+LZO_PUBLIC(int)
+DO_DECOMPRESS  ( const lzo_byte *in , lzo_uint  in_len,
+		       lzo_byte *out, lzo_uint *out_len,
+		       lzo_voidp wrkmem )
+#endif
+{
+    register lzo_byte *op;
+    register const lzo_byte *ip;
+    register lzo_uint t;
+#if defined(COPY_DICT)
+    lzo_uint m_off;
+    const lzo_byte *dict_end;
+#else
+    register const lzo_byte *m_pos;
+#endif
+
+    const lzo_byte * const ip_end = in + in_len;
+#if defined(HAVE_ANY_OP)
+    lzo_byte * const op_end = out + *out_len;
+#endif
+#if defined(LZO1Z)
+    lzo_uint last_m_off = 0;
+#endif
+
+    LZO_UNUSED(wrkmem);
+
+#if defined(__LZO_QUERY_DECOMPRESS)
+    if (__LZO_IS_DECOMPRESS_QUERY(in,in_len,out,out_len,wrkmem))
+	return __LZO_QUERY_DECOMPRESS(in,in_len,out,out_len,wrkmem,0,0);
+#endif
+
+#if defined(COPY_DICT)
+    if (dict)
+    {
+	if (dict_len > M4_MAX_OFFSET)
+	{
+	    dict += dict_len - M4_MAX_OFFSET;
+	    dict_len = M4_MAX_OFFSET;
+	}
+	dict_end = dict + dict_len;
+    }
+    else
+    {
+	dict_len = 0;
+	dict_end = NULL;
+    }
+#endif
+
+    *out_len = 0;
+
+    op = out;
+    ip = in;
+
+    if (*ip > 17)
+    {
+	t = *ip++ - 17;
+	if (t < 4)
+	    goto match_next;
+	assert(t > 0); NEED_OP(t); NEED_IP(t+1);
+	do *op++ = *ip++; while (--t > 0);
+	goto first_literal_run;
+    }
+
+    while (TEST_IP && TEST_OP)
+    {
+	t = *ip++;
+	if (t >= 16)
+	    goto match;
+	if (t == 0)
+	{
+	    NEED_IP(1);
+	    while (*ip == 0)
+	    {
+		t += 255;
+		ip++;
+		NEED_IP(1);
+	    }
+	    t += 15 + *ip++;
+	}
+	assert(t > 0); NEED_OP(t+3); NEED_IP(t+4);
+#if defined(LZO_UNALIGNED_OK_4) || defined(LZO_ALIGNED_OK_4)
+#if !defined(LZO_UNALIGNED_OK_4)
+	if (PTR_ALIGNED2_4(op,ip))
+	{
+#endif
+	* (lzo_uint32p) op = * (const lzo_uint32p) ip;
+	op += 4; ip += 4;
+	if (--t > 0)
+	{
+	    if (t >= 4)
+	    {
+		do {
+		    * (lzo_uint32p) op = * (const lzo_uint32p) ip;
+		    op += 4; ip += 4; t -= 4;
+		} while (t >= 4);
+		if (t > 0) do *op++ = *ip++; while (--t > 0);
+	    }
+	    else
+		do *op++ = *ip++; while (--t > 0);
+	}
+#if !defined(LZO_UNALIGNED_OK_4)
+	}
+	else
+#endif
+#endif
+#if !defined(LZO_UNALIGNED_OK_4)
+	{
+	    *op++ = *ip++; *op++ = *ip++; *op++ = *ip++;
+	    do *op++ = *ip++; while (--t > 0);
+	}
+#endif
+
+first_literal_run:
+
+	t = *ip++;
+	if (t >= 16)
+	    goto match;
+#if defined(COPY_DICT)
+#if defined(LZO1Z)
+	m_off = (1 + M2_MAX_OFFSET) + (t << 6) + (*ip++ >> 2);
+	last_m_off = m_off;
+#else
+	m_off = (1 + M2_MAX_OFFSET) + (t >> 2) + (*ip++ << 2);
+#endif
+	NEED_OP(3);
+	t = 3; COPY_DICT(t,m_off)
+#else
+#if defined(LZO1Z)
+	t = (1 + M2_MAX_OFFSET) + (t << 6) + (*ip++ >> 2);
+	m_pos = op - t;
+	last_m_off = t;
+#else
+	m_pos = op - (1 + M2_MAX_OFFSET);
+	m_pos -= t >> 2;
+	m_pos -= *ip++ << 2;
+#endif
+	TEST_LOOKBEHIND(m_pos,out); NEED_OP(3);
+	*op++ = *m_pos++; *op++ = *m_pos++; *op++ = *m_pos;
+#endif
+	goto match_done;
+
+	while (TEST_IP && TEST_OP)
+	{
+match:
+	    if (t >= 64)
+	    {
+#if defined(COPY_DICT)
+#if defined(LZO1X)
+		m_off = 1 + ((t >> 2) & 7) + (*ip++ << 3);
+		t = (t >> 5) - 1;
+#elif defined(LZO1Y)
+		m_off = 1 + ((t >> 2) & 3) + (*ip++ << 2);
+		t = (t >> 4) - 3;
+#elif defined(LZO1Z)
+		m_off = t & 0x1f;
+		if (m_off >= 0x1c)
+		    m_off = last_m_off;
+		else
+		{
+		    m_off = 1 + (m_off << 6) + (*ip++ >> 2);
+		    last_m_off = m_off;
+		}
+		t = (t >> 5) - 1;
+#endif
+#else
+#if defined(LZO1X)
+		m_pos = op - 1;
+		m_pos -= (t >> 2) & 7;
+		m_pos -= *ip++ << 3;
+		t = (t >> 5) - 1;
+#elif defined(LZO1Y)
+		m_pos = op - 1;
+		m_pos -= (t >> 2) & 3;
+		m_pos -= *ip++ << 2;
+		t = (t >> 4) - 3;
+#elif defined(LZO1Z)
+		{
+		    lzo_uint off = t & 0x1f;
+		    m_pos = op;
+		    if (off >= 0x1c)
+		    {
+			assert(last_m_off > 0);
+			m_pos -= last_m_off;
+		    }
+		    else
+		    {
+			off = 1 + (off << 6) + (*ip++ >> 2);
+			m_pos -= off;
+			last_m_off = off;
+		    }
+		}
+		t = (t >> 5) - 1;
+#endif
+		TEST_LOOKBEHIND(m_pos,out); assert(t > 0); NEED_OP(t+3-1);
+		goto copy_match;
+#endif
+	    }
+	    else if (t >= 32)
+	    {
+		t &= 31;
+		if (t == 0)
+		{
+		    NEED_IP(1);
+		    while (*ip == 0)
+		    {
+			t += 255;
+			ip++;
+			NEED_IP(1);
+		    }
+		    t += 31 + *ip++;
+		}
+#if defined(COPY_DICT)
+#if defined(LZO1Z)
+		m_off = 1 + (ip[0] << 6) + (ip[1] >> 2);
+		last_m_off = m_off;
+#else
+		m_off = 1 + (ip[0] >> 2) + (ip[1] << 6);
+#endif
+#else
+#if defined(LZO1Z)
+		{
+		    lzo_uint off = 1 + (ip[0] << 6) + (ip[1] >> 2);
+		    m_pos = op - off;
+		    last_m_off = off;
+		}
+#elif defined(LZO_UNALIGNED_OK_2) && (LZO_BYTE_ORDER == LZO_LITTLE_ENDIAN)
+		m_pos = op - 1;
+		m_pos -= (* (const lzo_ushortp) ip) >> 2;
+#else
+		m_pos = op - 1;
+		m_pos -= (ip[0] >> 2) + (ip[1] << 6);
+#endif
+#endif
+		ip += 2;
+	    }
+	    else if (t >= 16)
+	    {
+#if defined(COPY_DICT)
+		m_off = (t & 8) << 11;
+#else
+		m_pos = op;
+		m_pos -= (t & 8) << 11;
+#endif
+		t &= 7;
+		if (t == 0)
+		{
+		    NEED_IP(1);
+		    while (*ip == 0)
+		    {
+			t += 255;
+			ip++;
+			NEED_IP(1);
+		    }
+		    t += 7 + *ip++;
+		}
+#if defined(COPY_DICT)
+#if defined(LZO1Z)
+		m_off += (ip[0] << 6) + (ip[1] >> 2);
+#else
+		m_off += (ip[0] >> 2) + (ip[1] << 6);
+#endif
+		ip += 2;
+		if (m_off == 0)
+		    goto eof_found;
+		m_off += 0x4000;
+#if defined(LZO1Z)
+		last_m_off = m_off;
+#endif
+#else
+#if defined(LZO1Z)
+		m_pos -= (ip[0] << 6) + (ip[1] >> 2);
+#elif defined(LZO_UNALIGNED_OK_2) && (LZO_BYTE_ORDER == LZO_LITTLE_ENDIAN)
+		m_pos -= (* (const lzo_ushortp) ip) >> 2;
+#else
+		m_pos -= (ip[0] >> 2) + (ip[1] << 6);
+#endif
+		ip += 2;
+		if (m_pos == op)
+		    goto eof_found;
+		m_pos -= 0x4000;
+#if defined(LZO1Z)
+		last_m_off = op - m_pos;
+#endif
+#endif
+	    }
+	    else
+	    {
+#if defined(COPY_DICT)
+#if defined(LZO1Z)
+		m_off = 1 + (t << 6) + (*ip++ >> 2);
+		last_m_off = m_off;
+#else
+		m_off = 1 + (t >> 2) + (*ip++ << 2);
+#endif
+		NEED_OP(2);
+		t = 2; COPY_DICT(t,m_off)
+#else
+#if defined(LZO1Z)
+		t = 1 + (t << 6) + (*ip++ >> 2);
+		m_pos = op - t;
+		last_m_off = t;
+#else
+		m_pos = op - 1;
+		m_pos -= t >> 2;
+		m_pos -= *ip++ << 2;
+#endif
+		TEST_LOOKBEHIND(m_pos,out); NEED_OP(2);
+		*op++ = *m_pos++; *op++ = *m_pos;
+#endif
+		goto match_done;
+	    }
+
+#if defined(COPY_DICT)
+
+	    NEED_OP(t+3-1);
+	    t += 3-1; COPY_DICT(t,m_off)
+
+#else
+
+	    TEST_LOOKBEHIND(m_pos,out); assert(t > 0); NEED_OP(t+3-1);
+#if defined(LZO_UNALIGNED_OK_4) || defined(LZO_ALIGNED_OK_4)
+#if !defined(LZO_UNALIGNED_OK_4)
+	    if (t >= 2 * 4 - (3 - 1) && PTR_ALIGNED2_4(op,m_pos))
+	    {
+		assert((op - m_pos) >= 4);
+#else
+	    if (t >= 2 * 4 - (3 - 1) && (op - m_pos) >= 4)
+	    {
+#endif
+		* (lzo_uint32p) op = * (const lzo_uint32p) m_pos;
+		op += 4; m_pos += 4; t -= 4 - (3 - 1);
+		do {
+		    * (lzo_uint32p) op = * (const lzo_uint32p) m_pos;
+		    op += 4; m_pos += 4; t -= 4;
+		} while (t >= 4);
+		if (t > 0) do *op++ = *m_pos++; while (--t > 0);
+	    }
+	    else
+#endif
+	    {
+copy_match:
+		*op++ = *m_pos++; *op++ = *m_pos++;
+		do *op++ = *m_pos++; while (--t > 0);
+	    }
+
+#endif
+
+match_done:
+#if defined(LZO1Z)
+	    t = ip[-1] & 3;
+#else
+	    t = ip[-2] & 3;
+#endif
+	    if (t == 0)
+		break;
+
+match_next:
+	    assert(t > 0); NEED_OP(t); NEED_IP(t+1);
+	    do *op++ = *ip++; while (--t > 0);
+	    t = *ip++;
+	}
+    }
+
+#if defined(HAVE_TEST_IP) || defined(HAVE_TEST_OP)
+    *out_len = op - out;
+    return LZO_E_EOF_NOT_FOUND;
+#endif
+
+eof_found:
+    assert(t == 1);
+    *out_len = op - out;
+    return (ip == ip_end ? LZO_E_OK :
+	   (ip < ip_end  ? LZO_E_INPUT_NOT_CONSUMED : LZO_E_INPUT_OVERRUN));
+
+#if defined(HAVE_NEED_IP)
+input_overrun:
+    *out_len = op - out;
+    return LZO_E_INPUT_OVERRUN;
+#endif
+
+#if defined(HAVE_NEED_OP)
+output_overrun:
+    *out_len = op - out;
+    return LZO_E_OUTPUT_OVERRUN;
+#endif
+
+#if defined(LZO_TEST_DECOMPRESS_OVERRUN_LOOKBEHIND)
+lookbehind_overrun:
+    *out_len = op - out;
+    return LZO_E_LOOKBEHIND_OVERRUN;
+#endif
+}
+
+/***** End of minilzo.c *****/
+

--- a/tools/Pal3CpkTool/Pal3CpkTool/minilzo/minilzo.h
+++ b/tools/Pal3CpkTool/Pal3CpkTool/minilzo/minilzo.h
@@ -1,0 +1,95 @@
+/* minilzo.h -- mini subset of the LZO real-time data compression library
+
+   This file is part of the LZO real-time data compression library.
+
+   Copyright (C) 1998 Markus Franz Xaver Johannes Oberhumer
+   Copyright (C) 1997 Markus Franz Xaver Johannes Oberhumer
+   Copyright (C) 1996 Markus Franz Xaver Johannes Oberhumer
+
+   The LZO library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU General Public License as
+   published by the Free Software Foundation; either version 2 of
+   the License, or (at your option) any later version.
+
+   The LZO library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with the LZO library; see the file COPYING.
+   If not, write to the Free Software Foundation, Inc.,
+   59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+
+   Markus F.X.J. Oberhumer
+   <markus.oberhumer@jk.uni-linz.ac.at>
+   http://wildsau.idv.uni-linz.ac.at/mfx/lzo.html
+ */
+
+/*
+ * NOTE:
+ *   the full LZO package can be found at
+ *   http://wildsau.idv.uni-linz.ac.at/mfx/lzo.html
+ */
+
+
+#ifndef __MINILZO_H
+#define __MINILZO_H
+
+#define MINILZO_VERSION         0x1040
+
+#ifdef __LZOCONF_H
+#  error "you cannot use both LZO and miniLZO"
+#endif
+
+#undef LZO_HAVE_CONFIG_H
+#include "lzoconf.h"
+
+#if !defined(LZO_VERSION) || (LZO_VERSION != MINILZO_VERSION)
+#  error "version mismatch in header files"
+#endif
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/***********************************************************************
+//
+************************************************************************/
+
+/* Memory required for the wrkmem parameter.
+ * When the required size is 0, you can also pass a NULL pointer.
+ */
+
+#define LZO1X_MEM_COMPRESS      LZO1X_1_MEM_COMPRESS
+#define LZO1X_1_MEM_COMPRESS    ((lzo_uint32) (16384L * lzo_sizeof_dict_t))
+#define LZO1X_MEM_DECOMPRESS    (0)
+
+
+/* compression */
+LZO_EXTERN(int)
+lzo1x_1_compress        ( const lzo_byte *src, lzo_uint  src_len,
+                                lzo_byte *dst, lzo_uint *dst_len,
+                                lzo_voidp wrkmem );
+
+/* decompression */
+LZO_EXTERN(int)
+lzo1x_decompress        ( const lzo_byte *src, lzo_uint  src_len,
+                                lzo_byte *dst, lzo_uint *dst_len,
+                                lzo_voidp wrkmem /* NOT USED */ );
+
+/* safe decompression with overrun testing */
+LZO_EXTERN(int)
+lzo1x_decompress_safe   ( const lzo_byte *src, lzo_uint  src_len,
+                                lzo_byte *dst, lzo_uint *dst_len,
+                                lzo_voidp wrkmem /* NOT USED */ );
+
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* already included */
+

--- a/tools/Pal3CpkTool/gbEngineTest/gbEngineTest.cpp
+++ b/tools/Pal3CpkTool/gbEngineTest/gbEngineTest.cpp
@@ -34,18 +34,19 @@ struct CpkFileEntry {
 };
 
 class CPKFile {
-    bool bUsed;                     //0x110
-    DWORD vID;                      //0x114
-    DWORD parentVID;                //0x118
-    DWORD fileIndex;                //0x11C
-    LPVOID lpMapFileBase;           //0x120
-    void* pSrc;                     //0x124
-    DWORD offset;                   //0x128
-    bool bFlag;                     //0x12C
-    void* pDest;                    //0x130
-    DWORD originalSize;             //0x134
-    DWORD dwFlag;                   //0x138
-    CpkFileEntry* pRecordEntry;     //0x13C
+public:
+    bool bOpened;                   //0x110     是否打开
+    DWORD vCRC;                     //0x114     本节点CRC
+    DWORD vParentCRC;               //0x118     父节点CRC
+    DWORD fileIndex;                //0x11C     文件数组下标
+    LPVOID lpMapFileBase;           //0x120     文件映射基址
+    void* pSrc;                     //0x124     文件原始缓冲
+    DWORD srcOffset;                //0x128     对齐字节
+    bool isCompressed;              //0x12C     是否是压缩文件
+    void* pDest;                    //0x130     解压缓冲区
+    DWORD originalSize;             //0x134     原始文件大小
+    DWORD fileOffset;               //0x138     文件偏移
+    CpkFileEntry* pRecordEntry;     //0x13C     文件结构指针
 };
 
 //0x140
@@ -109,25 +110,25 @@ private:
 public:
     CPK(void);
     ~CPK(void);
-    bool Close(class CPKFile *);
+    bool Close(CPKFile *);
     bool IsFileExist(char const *);
     bool IsLoaded(void);
     bool IsValidCPK(char const *);
     bool Load(char const *);
-    bool Read(void *, unsigned long, class CPKFile *);
+    bool Read(void *, unsigned long, CPKFile *);
     bool Unload(void);
-    char * ReadLine(char *, int, class CPKFile *);
+    char * ReadLine(char *, int, CPKFile *);
     class CPK & operator=(class CPK const &);
-    class CPKFile * Open(char const *);
-    int ReadChar(class CPKFile *);
+    CPKFile * Open(char const *);
+    int ReadChar(CPKFile *);
     unsigned long Compress(void *, void *, unsigned long);
     unsigned long DeCompress(void *, void *, unsigned long);
     unsigned long GetCPKHandle(void);
-    unsigned long GetSize(class CPKFile *);
+    unsigned long GetSize(CPKFile *);
     unsigned long LoadFile(void *, char const *);
-    unsigned long Seek(class CPKFile *, int, unsigned long);
-    unsigned long Tell(class CPKFile *);
-    void Rewind(class CPKFile *);
+    unsigned long Seek(CPKFile *, int, unsigned long);
+    unsigned long Tell(CPKFile *);
+    void Rewind(CPKFile *);
     void SetOpenMode(enum ECPKMode);
 };
 
@@ -139,12 +140,9 @@ int main()
     bool bOk = cpk.Load("E:\\PAL3\\basedata\\basedata.cpk");
     if (!bOk)
         return -1;
-    bOk = cpk.Open("gfxscript\\white.tga");
-    if (!bOk)
+    CPKFile* pFile = cpk.Open("ui\\UILib\\8.tga");
+    if (!pFile)
         return -1;
-    HMODULE hGbEngine = LoadLibraryA("E:\\PAL3\\gbengine.dll");
-    typedef unsigned long (*PFnCrc)(char const *);
-    PFnCrc Crc = (PFnCrc)GetProcAddress(hGbEngine, "?Crc@CPK@@CAKPBD@Z");
-    DWORD dwCrc = Crc("gfxscript\\white.tga");
+    pFile->bOpened;
     return 0;
 }


### PR DESCRIPTION
The issue in CPK::Open is that we map a wrong and lager length for
cpk file, I wonder why IDA hex rays makes this mistake.

Signed-off-by: SlayerNux <530948159@qq.com>