### PR TITLE
添加了uncpk_PAL3.bat进行cpk解压

### DIFF
--- a/opengb/Cargo.toml
+++ b/opengb/Cargo.toml
@@ -21,3 +21,4 @@ downcast-rs = "1.1.1"
 config = "0.10.1"
 serde = { version = "1.0.106", features = ["derive"] }
 intercom = { git = "https://github.com/dontpanic92/intercom/" }
+winapi = "0.3.8"

--- a/opengb/src/cpk/cpk.rs
+++ b/opengb/src/cpk/cpk.rs
@@ -1,0 +1,146 @@
+use std::libc;
+use std::os::raw::c_char;
+use winapi::HANDLE;
+use lazy_static::*;
+
+pub enum CPKTableFlag {
+    CPKTableFlag_None = 0x0,
+    CPKTableFlag_IsFile = 0x1,         //是否是合法文件？
+    CPKTableFlag_IsDir = 0x2,          //是否是目录
+    CPKTableFlag_Unknown2 = 0x4,
+    CPKTableFlag_Unknown3 = 0x8,
+    CPKTableFlag_IsDeleted = 0x10,     //是否已删除
+}
+
+struct CPKTable {
+    dwCRC: winapi::DWORD,                //0x00  当前节点CRC
+    dwFlag:  CPKTableFlag,          //0x04  文件属性信息
+    dwFatherCRC: winapi::DWORD,          //0x08  父节点CRC，根节点为0
+    dwStartPos: winapi::DWORD,           //0x0C  压缩后的数据在CPK中的偏移量。
+    dwPackedSize: winapi::DWORD,         //0x10  压缩后数据的大小。对于目录，这个值为0。
+    dwOriginSize: winapi::DWORD,         //0x14  原始文件的大小，方便你解压时开缓冲区。
+    dwExtraInfoSize: winapi::DWORD,      //0x18  文件名信息偏移 信息紧跟着压缩数据之后，所以从dwStartPos + dwPackedSize读取dwExtraInfoSize，最开头就是文件名
+}
+
+
+pub struct CPKFile {
+        bValid: bool,                 //0x110 是否有效
+        dwCRC: winapi::DWORD,              //0x114 
+        dwFatherCRC: winapi::DWORD,        //0x118 父节点CRC
+        nTableIndex: winapi::DWORD,        //0x11C 文件数组下标
+        lpMapAddress: void,           //0x120 文件映射基址
+        void: lpStartAddress,         //0x124 文件原始缓冲
+        dwOffset: winapi::DWORD,           //0x128 对齐偏移量
+        bCompressed: bool,            //0x12C 是否是压缩文件
+        lpMem: *mut void,             //0x130 一般存放解压缩内容
+        dwFileSize: winapi::DWORD,         //0x134 原始文件大小
+        dwPointer: winapi::DWORD,          //0x138 文件指针
+        pRecordEntry: *mut CPKTable,  //0x13C 文件结构指针
+    }
+
+//0x140
+struct gbVFile {
+    OpenMode: winapi::DWORD,                 //0x0
+    EntryAddr: winapi::DWORD,                //0x4
+    FileSize: winapi::DWORD,                 //0x8
+    fileName: [::std::os::c_char; 260usize],        //0xC       文件名
+    cpkFile: *mut CPKFile,
+}
+
+pub struct CpkZipUnzipParam {
+    flag: int32_t,                  //0x00  一般为2，从CpkFileEntry::Attrib的HIWORD复制
+    bCompress: bool,                //0x04  是否启用压缩
+    src: *mut void,                 //0x08  文件源数据指针
+    dest: *mut void,                //0x0C  文件目标数据指针
+    srcSizeUnused: winapi::DWORD,        //0x10  暂时未发现有使用
+    destSize: winapi::DWORD,             //0x14  目标数据大小
+    srcSize: winapi::DWORD,              //0x18  源数据大小
+    destResultSize: winapi::DWORD,       //0x1C  实际得到的数据大小
+    bResult: bool,                  //0x20  操作是否成功
+}
+
+//0x80
+pub struct CPKHeader {
+    dwLable: winapi::DWORD,                  //0x0
+    dwVersion: winapi::DWORD,                //0x4   版本 必须为1
+    dwTableStart: winapi::DWORD,             //0x08
+    dwDataStart: winapi::DWORD,              //0x0C
+    dwMaxFileNum: winapi::DWORD,             //0x10  最大文件数量
+    dwFileNum: winapi::DWORD,                //0x14  文件数量
+    dwIsFormatted: winapi::DWORD,            //0x18
+    dwSizeOfHeader: winapi::DWORD,           //0x1C
+    dwValidTableNum: winapi::DWORD,          //0x20  CpkFileEntry数组数量
+    dwMaxTableNum: winapi::DWORD,            //0x24
+    dwFragmentNum: winapi::DWORD,            //0x28
+    dwPackageSize: winapi::DWORD,            //0x2C
+    dwReserved: [winapi::DWORD; 20usize],    //0x30
+}
+
+pub enum ECPKMode {
+    CPKM_Null = 0,
+    CPKM_Normal = 1,
+    CPKM_FileMapping = 2,
+    CPKM_Overlapped = 3,
+    CPKM_End = 4,
+}
+
+pub enum ECPKSeekFileType {
+    ECPKSeekFileType_Set = 0,
+    ECPKSeekFileType_Add = 1,
+    ECPKSeekFileType_Sub = 2,
+}
+
+
+//CPK 全局变量
+static CrcTable: [*mut uint32; 256];
+static lzo_wrkmem: *mut void;
+static g_bCrcTableInitialized: bool = false;
+
+pub struct CPK {
+
+    dwAllocationGranularity: winapi::DWORD,                  //0x0           块对齐长度，做文件映射时需要对齐到该长度，否则映射失败
+    m_eMode: ECPKMode,                               //0x4           打开模式 当前为ECPKMode_Mapped
+    cpkHeader: CPKHeader,                            //0x8           文件头信息
+    entries: [CPKTable;32768],                    //0x88          文件节点信息数组，通过哈希存储
+    m_pgbVFile: [*mut gbVFile;0x8],                       //0xE0088       文件数组
+    m_bLoaded: bool,                                 //0xE00A8       是否已加载
+    m_dwCPKHandle: HANDLE,                           //0xE0090       文件句柄
+    m_dwCPKMappingHandle: HANDLE,                    //0xE0094       文件映射句柄
+    fileName: [::std::os::c_char;260],                        //0xE0098       CPK文件名
+    m_nOpenedFileNum: winapi::DWORD,                         //0xE009C       当前打开的gbVFile文件数量
+}
+
+impl CPK {
+    pub fn new() -> Self {
+        winapi::memset(Box::into_raw(Self),0, sizeof(Self));
+        m_eMode = CPKM_FileMapping;
+        dwAllocationGranularity = GetAllocationGranularity();
+        if !g_bCrcTableInitialized {
+
+        }
+
+    }
+
+    fn GetAllocationGranularity() -> winapi::DWORD
+    {
+        let SystemInfo: winapi::_SYSTEM_INFO = winapi::_SYSTEM_INFO::new();
+        winapi::GetSystemInfo(&SystemInfo);
+        return SystemInfo.dwAllocationGranularity;
+    }
+
+    fn InitCrcTable() {
+        let index: i32 = 0;
+        let _crcTable : **mut winapi::DWORD;
+        
+        if !g_bCrcTableInitialized {
+
+        }
+    }
+
+    // pub fn Close(pCpkFile: &CPKFile) -> bool {
+    //     if Self.
+    //     if pCpkFile.lpMapAddress != nullptr {
+
+    //     }
+    // }
+}

--- a/tools/Pal3CpkTool/Pal3CpkTool/CPK.h
+++ b/tools/Pal3CpkTool/Pal3CpkTool/CPK.h
@@ -43,9 +43,9 @@ public:
 };
 
 //0x140
-struct gbVFile : CPKFile {
+struct gbVFile {
     DWORD OpenMode;                 //0x0
-    DWORD EntryAddr;                 //0x4
+    DWORD EntryAddr;                //0x4
     DWORD FileSize;                 //0x8
     char fileName[MAX_PATH];        //0xC       ÎÄ¼þÃû
     CPKFile cpkFile;

--- a/tools/Pal3CpkTool/Pal3CpkTool/CPK.h
+++ b/tools/Pal3CpkTool/Pal3CpkTool/CPK.h
@@ -99,7 +99,7 @@ class CPKDirectoryEntry {
 
 public:
     CPKDirectoryEntry()
-        :vCRC(0), vParentCRC(0), lpszName{ 0 }, iAttrib(CPKTableFlag_None)
+        :dwCRC(0), dwFatherCRC(0), lpszName{ 0 }, dwFlag(CPKTableFlag_None)
     {
     }
     ~CPKDirectoryEntry()
@@ -108,9 +108,9 @@ public:
             delete childs[i];
         childs.clear();
     }
-    DWORD vCRC;
-    DWORD vParentCRC;
-    CPKTableFlag iAttrib;
+    DWORD dwCRC;
+    DWORD dwFatherCRC;
+    CPKTableFlag dwFlag;
     CHAR lpszName[MAX_PATH];
     std::vector<CPKDirectoryEntry*> childs;
 };
@@ -143,7 +143,6 @@ public:
     void SetOpenMode(ECPKMode openMode);
 
     bool BuildDirectoryTree(CPKDirectoryEntry& entry);
-    bool buildParent(CPKTable& currEntry, std::map<DWORD, CPKDirectoryEntry*>& handledEntries);
 
 private:
     int executeZipUnZip(CpkZipUnzipParam *param);
@@ -159,6 +158,8 @@ private:
     DWORD GetAllocationGranularity(void);
     void Reset();
     bool ReadFileEntryName(const CPKTable* pFileEntry, char* lpBuffer, DWORD bufferLen);
+    void sortCPKDirectory(CPKDirectoryEntry* pEntry);
+    bool buildParent(CPKTable& currEntry, std::map<DWORD, CPKDirectoryEntry*>& handledEntries);
 
 
 

--- a/tools/Pal3CpkTool/Pal3CpkTool/main.cpp
+++ b/tools/Pal3CpkTool/Pal3CpkTool/main.cpp
@@ -53,7 +53,7 @@ bool decompress(CPK* cpk, const char* rootPath, CPKDirectoryEntry* pDirectoryEnt
             sprintf_s(pDirectoryEntry->lpszName, sizeof(pDirectoryEntry->lpszName), "deleted_%d", g_deletedCount++);
     }*/
     sprintf_s(absPath, sizeof(absPath), "%s\\%s", rootPath, pDirectoryEntry->lpszName);
-    if (pDirectoryEntry->iAttrib & CPKTableFlag_IsDir) {
+    if (pDirectoryEntry->dwFlag & CPKTableFlag_IsDir) {
         createDirectory(absPath);
         for (int i = 0; i < pDirectoryEntry->childs.size(); i++) {
             decompress(cpk, rootPath, pDirectoryEntry->childs[i]);
@@ -62,7 +62,7 @@ bool decompress(CPK* cpk, const char* rootPath, CPKDirectoryEntry* pDirectoryEnt
         //open file and decompress it
         if (!strlen(pDirectoryEntry->lpszName))
             return true;
-        CPKFile* pFile = cpk->Open(pDirectoryEntry->vCRC, pDirectoryEntry->lpszName);
+        CPKFile* pFile = cpk->Open(pDirectoryEntry->dwCRC, pDirectoryEntry->lpszName);
         if (!pFile)
             return false;
         assert(pFile);

--- a/tools/Pal3CpkTool/Pal3CpkTool/uncpk_PAL3.bat
+++ b/tools/Pal3CpkTool/Pal3CpkTool/uncpk_PAL3.bat
@@ -1,0 +1,57 @@
+@ECHO OFF
+
+ECHO PAL3 CPK UNPACKER
+ECHO.
+PAUSE
+
+SET CPKUNPACKER=Pal3CpkTool.exe
+
+%CPKUNPACKER% .\basedata\basedata.cpk .\basedata
+%CPKUNPACKER% .\movie\movie.cpk .
+%CPKUNPACKER% .\movie\movie_end.cpk .
+%CPKUNPACKER% .\music\music.cpk .
+%CPKUNPACKER% .\scene\M01.cpk .\scene\M01
+%CPKUNPACKER% .\scene\M02.cpk .\scene\M02
+%CPKUNPACKER% .\scene\M03.cpk .\scene\M03
+%CPKUNPACKER% .\scene\M04.cpk .\scene\M04
+%CPKUNPACKER% .\scene\M05.cpk .\scene\M05
+%CPKUNPACKER% .\scene\M06.cpk .\scene\M06
+%CPKUNPACKER% .\scene\m08.cpk .\scene\m08
+%CPKUNPACKER% .\scene\M09.cpk .\scene\M09
+%CPKUNPACKER% .\scene\m10.cpk .\scene\m10
+%CPKUNPACKER% .\scene\m11.cpk .\scene\m11
+%CPKUNPACKER% .\scene\M15.cpk .\scene\M15
+%CPKUNPACKER% .\scene\M16.cpk .\scene\M16
+%CPKUNPACKER% .\scene\M17.cpk .\scene\M17
+%CPKUNPACKER% .\scene\M18.cpk .\scene\M18
+%CPKUNPACKER% .\scene\M19.cpk .\scene\M19
+%CPKUNPACKER% .\scene\M20.cpk .\scene\M20
+%CPKUNPACKER% .\scene\M21.cpk .\scene\M21
+%CPKUNPACKER% .\scene\M22.cpk .\scene\M22
+%CPKUNPACKER% .\scene\M23.cpk .\scene\M23
+%CPKUNPACKER% .\scene\M24.cpk .\scene\M24
+%CPKUNPACKER% .\scene\M25.cpk .\scene\M25
+%CPKUNPACKER% .\scene\M26.cpk .\scene\M26
+%CPKUNPACKER% .\scene\Q01.cpk .\scene\Q01
+%CPKUNPACKER% .\scene\Q02.cpk .\scene\Q02
+%CPKUNPACKER% .\scene\Q03.cpk .\scene\Q03
+%CPKUNPACKER% .\scene\Q04.cpk .\scene\Q04
+%CPKUNPACKER% .\scene\Q05.cpk .\scene\Q05
+%CPKUNPACKER% .\scene\Q06.cpk .\scene\Q06
+%CPKUNPACKER% .\scene\Q07.cpk .\scene\Q07
+%CPKUNPACKER% .\scene\Q08.cpk .\scene\Q08
+%CPKUNPACKER% .\scene\Q09.cpk .\scene\Q09
+%CPKUNPACKER% .\scene\Q10.cpk .\scene\Q10
+%CPKUNPACKER% .\scene\Q11.cpk .\scene\Q11
+%CPKUNPACKER% .\scene\Q12.cpk .\scene\Q12
+%CPKUNPACKER% .\scene\Q13.cpk .\scene\Q13
+%CPKUNPACKER% .\scene\Q14.cpk .\scene\Q14
+%CPKUNPACKER% .\scene\Q15.cpk .\scene\Q15
+%CPKUNPACKER% .\scene\Q16.cpk .\scene\Q16
+%CPKUNPACKER% .\scene\Q17.cpk .\scene\Q17
+%CPKUNPACKER% .\scene\T01.cpk .\scene\T01
+%CPKUNPACKER% .\scene\T02.cpk .\scene\T02
+
+ECHO.
+ECHO ALL FINISHED!
+PAUSE


### PR DESCRIPTION
从PAL3patch项目中拷贝了uncpk_PAL3.bat，简单修改了代码，配合该脚本进行cpk的批量解压
使用方式：
将生成的Pal3CpkTool.exe和uncpk_PAL3.bat拷贝到PAL3.exe所在目录，执行脚本即可，会加压所有cpk文件到正确的目录。