### PR TITLE
fix: don't show mutable objects by default

### DIFF
--- a/opengb/src/asset_manager.rs
+++ b/opengb/src/asset_manager.rs
@@ -175,6 +175,7 @@ impl AssetManager {
             Some(CoreEntity::new(
                 PolModelEntity::new(&self.factory, &self.vfs, &path),
                 format!("OBJECT_{}", index),
+                true
             ))
         } else {
             None
@@ -200,6 +201,7 @@ impl AssetManager {
                 &self.vfs,
                 &path,
                 format!("OBJECT_{}", index),
+                true
             ))
         } else {
             None
@@ -210,12 +212,14 @@ impl AssetManager {
         &self,
         obj_name: &str,
         index: u16,
+        visible: bool,
     ) -> Option<CoreEntity<PolModelEntity>> {
         let path = self.get_object_item_path(obj_name);
         if self.vfs.open(&path).is_ok() {
             Some(CoreEntity::new(
                 PolModelEntity::new(&self.factory, &self.vfs, &path),
                 format!("OBJECT_{}", index),
+                visible,
             ))
         } else {
             None
@@ -226,6 +230,7 @@ impl AssetManager {
         &self,
         obj_name: &str,
         index: u16,
+        visible: bool,
     ) -> Option<CoreEntity<CvdModelEntity>> {
         let path = self.get_object_item_path(obj_name);
         if self.vfs.open(&path).is_ok() {
@@ -234,6 +239,7 @@ impl AssetManager {
                 &self.vfs,
                 &path,
                 format!("OBJECT_{}", index),
+                visible
             ))
         } else {
             None

--- a/opengb/src/scene/cvd_entity.rs
+++ b/opengb/src/scene/cvd_entity.rs
@@ -22,6 +22,7 @@ impl CvdModelEntity {
         vfs: &MiniFs,
         path: P,
         name: String,
+        visible: bool,
     ) -> CoreEntity<Self> {
         let cvd = cvd_load_from_file(vfs, path.as_ref()).unwrap();
         let mut entity = CoreEntity::new(
@@ -33,6 +34,7 @@ impl CvdModelEntity {
                 meshes: vec![],
             },
             name,
+            visible
         );
 
         for (i, node) in cvd.models.iter().enumerate() {
@@ -41,6 +43,7 @@ impl CvdModelEntity {
                 vfs,
                 path.as_ref(),
                 node,
+                visible
             )));
         }
 
@@ -52,6 +55,7 @@ impl CvdModelEntity {
         vfs: &MiniFs,
         path: P,
         node: &CvdModelNode,
+        visible: bool,
     ) -> CoreEntity<Self> {
         let mut scale_factor = 1.;
         let mut position_keyframes = None;
@@ -93,6 +97,7 @@ impl CvdModelEntity {
                 meshes,
             },
             "cvd_obj".to_string(),
+            true
         );
 
         entity.setup_transform(scale_factor);
@@ -104,6 +109,7 @@ impl CvdModelEntity {
                     vfs,
                     path.as_ref(),
                     &child,
+                    visible
                 )));
             }
         }

--- a/opengb/src/scene/role_entity.rs
+++ b/opengb/src/scene/role_entity.rs
@@ -98,6 +98,7 @@ impl RoleEntity {
         } else {
             self.remove_component::<RenderingComponent>();
         }
+        self.set_visible(active);
     }
 
     pub fn play_anim(

--- a/opengb/src/scene/scene.rs
+++ b/opengb/src/scene/scene.rs
@@ -292,6 +292,7 @@ impl ScnScene {
                 });
             }
 
+            let visible = obj.node_type != 17 && obj.node_type != 25;
             if obj.node_type != 37 && obj.node_type != 43 && obj.name.len() != 0 {
                 if obj.name.as_bytes()[0] as char == '_' {
                     if let Some(p) = _self.asset_mgr.load_scn_pol(
@@ -315,14 +316,14 @@ impl ScnScene {
                     entity = Some(Box::new(
                         _self
                             .asset_mgr
-                            .load_object_item_pol(&obj.name, obj.index)
+                            .load_object_item_pol(&obj.name, obj.index, visible)
                             .unwrap(),
                     ));
                 } else if obj.name.to_lowercase().ends_with(".cvd") {
                     entity = Some(Box::new(
                         _self
                             .asset_mgr
-                            .load_object_item_cvd(&obj.name, obj.index)
+                            .load_object_item_cvd(&obj.name, obj.index, visible)
                             .unwrap(),
                     ));
                 } else if obj.name.as_bytes()[0] as char == '+' {
@@ -332,7 +333,7 @@ impl ScnScene {
                     entity = Some(Box::new(
                         _self
                             .asset_mgr
-                            .load_object_item_pol(&obj.name, obj.index)
+                            .load_object_item_pol(&obj.name, obj.index, visible)
                             .unwrap(),
                     ));
                 }
@@ -371,14 +372,14 @@ impl ScnScene {
             let entity_name = format!("ROLE_{}", i);
             let model_name = Self::map_role_id(*i).to_string();
             let role_entity = self.asset_mgr.load_role(&model_name, "C01").unwrap();
-            let entity = CoreEntity::new(role_entity, entity_name);
+            let entity = CoreEntity::new(role_entity, entity_name, false);
             self.add_entity(Box::new(entity));
         }
 
         let mut entities = vec![];
         for role in &self.scn_file.roles {
             if let Some(role_entity) = self.asset_mgr.load_role(&role.name, &role.action_name) {
-                let mut entity = CoreEntity::new(role_entity, format!("ROLE_{}", role.index));
+                let mut entity = CoreEntity::new(role_entity, format!("ROLE_{}", role.index), false);
                 entity
                     .transform_mut()
                     .set_position(&Vec3::new(

--- a/radiance/src/scene/entity.rs
+++ b/radiance/src/scene/entity.rs
@@ -48,14 +48,14 @@ pub struct CoreEntity<TExtension: EntityExtension> {
 }
 
 impl<TExtension: EntityExtension + 'static> CoreEntity<TExtension> {
-    pub fn new(extension: TExtension, name: String) -> Self {
+    pub fn new(extension: TExtension, name: String, visible: bool) -> Self {
         Self {
             name,
             transform: Transform::new(),
             world_transform: Transform::new(),
             components: HashMap::new(),
             children: vec![],
-            visible: true,
+            visible,
             extension,
         }
     }

--- a/tools/dev_tools/src/directors/preview_director.rs
+++ b/tools/dev_tools/src/directors/preview_director.rs
@@ -61,6 +61,7 @@ impl Director for PreviewDirector {
                             a,
                         ),
                         "preview".to_string(),
+                        true
                     ));
                     e.set_active(true);
                     e as Box<dyn Entity>
@@ -74,12 +75,14 @@ impl Director for PreviewDirector {
                     &self.path,
                 ),
                 "preview".to_string(),
+                true
             )) as Box<dyn Entity>),
             Some("cvd") => Some(Box::new(CvdModelEntity::create(
                 self.asset_mgr.component_factory().clone(),
                 &self.asset_mgr.vfs(),
                 &self.path,
                 "preview".to_string(),
+                true
             )) as Box<dyn Entity>),
             _ => None,
         };


### PR DESCRIPTION
Mutable objects are ROLEs and OBJECTS(with type == 17 || type == 25). We can change roles' visibility by RoleActive, and objects' by ObjectActive.  So, don't show them by default.