### PR TITLE
feat: add command: CameraRotate

### DIFF
--- a/radiance/radiance/src/math/transform.rs
+++ b/radiance/radiance/src/math/transform.rs
@@ -8,7 +8,7 @@ pub struct Transform {
 }
 
 impl Transform {
-    const EPS: f32 = 0.0001;
+    pub const EPS: f32 = 0.0001;
 
     pub fn new() -> Self {
         Self {
@@ -26,6 +26,23 @@ impl Transform {
 
     pub fn position(&self) -> Vec3 {
         Vec3::new(self.mat[0][3], self.mat[1][3], self.mat[2][3])
+    }
+
+    pub fn euler(&self) -> Vec3 {
+        let sy = (self.mat[0][0] * self.mat[0][0] + self.mat[1][0] * self.mat[1][0]).sqrt();
+        let singular = sy < Self::EPS;
+
+        if !singular {
+            let x = self.mat[2][0].atan2(sy).to_degrees();
+            let y = self.mat[2][1].atan2(self.mat[2][2]).to_degrees();
+            let z = self.mat[1][0].atan2(self.mat[0][0]).to_degrees();
+            Vec3::new(x, y, z)
+        } else {
+            let x = self.mat[2][0].atan2(sy).to_degrees();
+            let y = (-self.mat[1][2]).atan2(self.mat[1][1]).to_degrees();
+            let z = 0.;
+            Vec3::new(x, y, z)
+        }
     }
 
     pub fn set_matrix(&mut self, mat: Mat44) -> &mut Self {

--- a/radiance/radiance/src/math/vec.rs
+++ b/radiance/radiance/src/math/vec.rs
@@ -42,6 +42,12 @@ impl Vec3 {
         z: 0.,
     };
 
+    pub const EAST: Self = Vec3 {
+        x: 1.,
+        y: 0.,
+        z: 0.,
+    };
+
     pub fn new(x: f32, y: f32, z: f32) -> Self {
         Vec3 { x, y, z }
     }

--- a/yaobow/shared/src/scripting/sce/commands/camera_rotate.rs
+++ b/yaobow/shared/src/scripting/sce/commands/camera_rotate.rs
@@ -1,0 +1,71 @@
+use crate::scripting::sce::{SceCommand, SceState};
+use crosscom::ComRc;
+use imgui::Ui;
+use radiance::comdef::ISceneManager;
+use radiance::math::{Vec3, Transform};
+
+#[derive(Debug, Clone)]
+pub struct SceCommandCameraRotate {
+    to_rot_x: f32,
+    to_rot_y: f32,
+    duration: f32,
+    spent: f32,
+    _unknown: i32,
+}
+
+impl SceCommand for SceCommandCameraRotate {
+    fn update(
+        &mut self,
+        scene_manager: ComRc<ISceneManager>,
+        _ui: &Ui,
+        _state: &mut SceState,
+        _delta_sec: f32,
+    ) -> bool {
+        let scene = scene_manager.scene().unwrap();
+        let cam_rot = scene.camera().borrow().transform().euler();
+
+        let left = (self.duration - self.spent).abs();
+        let (x_rot, y_rot) = if left > Transform::EPS {
+            let (mut x, mut y) = (
+                (self.to_rot_x - cam_rot.x).to_radians() / left * _delta_sec,
+                (self.to_rot_y - cam_rot.y).to_radians() / left * _delta_sec
+            );
+            if x.abs() < Transform::EPS {
+                x = 0.;
+            }
+            if y.abs() < Transform::EPS {
+                y = 0.;
+            }
+            (x, y)
+        } else {
+            return true;
+        };
+
+        scene
+            .camera()
+            .borrow_mut()
+            .transform_mut()
+            .rotate_axis_angle(&Vec3::UP, -x_rot)
+            .rotate_axis_angle(&Vec3::EAST, -y_rot);
+
+        self.spent += _delta_sec;
+        self.spent > self.duration
+    }
+}
+
+impl SceCommandCameraRotate {
+    pub fn new(
+        to_rot_x: f32,
+        to_rot_y: f32,
+        duration: f32,
+        _unknown: i32,
+    ) -> Self {
+        Self {
+            to_rot_x,
+            to_rot_y,
+            duration,
+            spent: 0.,
+            _unknown,
+        }
+    }
+}

--- a/yaobow/shared/src/scripting/sce/commands/mod.rs
+++ b/yaobow/shared/src/scripting/sce/commands/mod.rs
@@ -3,6 +3,7 @@ mod between;
 mod call;
 mod camera_default;
 mod camera_move;
+mod camera_rotate;
 mod camera_set;
 mod cmp;
 mod dlg;
@@ -54,6 +55,7 @@ pub use between::SceCommandBetween;
 pub use call::SceCommandCall;
 pub use camera_default::SceCommandCameraDefault;
 pub use camera_move::SceCommandCameraMove;
+pub use camera_rotate::SceCommandCameraRotate;
 pub use camera_set::SceCommandCameraSet;
 pub use cmp::{
     SceCommandEq, SceCommandGeq, SceCommandGeq2, SceCommandGt, SceCommandLeq, SceCommandLs,

--- a/yaobow/shared/src/scripting/sce/vm.rs
+++ b/yaobow/shared/src/scripting/sce/vm.rs
@@ -397,7 +397,7 @@ impl SceProcContext {
             }
             33 => {
                 // CameraRotate
-                nop_command!(self, CameraRotate, f32, f32, f32, i32)
+                command!(self, SceCommandCameraRotate, to_rot_x: f32, to_rot_y: f32, duration: f32, _unknown: i32)
             }
             34 => {
                 // CameraMove


### PR DESCRIPTION
实现方法：
通过camera的旋转矩阵计算得到当前的欧拉角，旋转camera一直到设定值。

使用场景：
雪见登场场景中，景天修复好茶壶盖后，景天兴奋地跳起来，伴随着胜利音效。
