### PR TITLE
Fix RoleTurnFace and RolePathTo

### DIFF
--- a/yaobow/shared/src/scripting/sce/commands/role_path_to.rs
+++ b/yaobow/shared/src/scripting/sce/commands/role_path_to.rs
@@ -72,9 +72,14 @@ impl SceCommand for SceCommandRolePathTo {
             Vec3::add(&position, &Vec3::dot(step, &Vec3::normalized(&remain)))
         };
 
+        let mut look_at = Vec3::new(to.x, position.y, to.z);
+        if self.run == 2 {
+            look_at = Vec3::add(&position, &Vec3::sub(&position, &to));
+        }
+
         role.transform()
             .borrow_mut()
-            .look_at(&Vec3::new(to.x, position.y, to.z))
+            .look_at(&look_at)
             .set_position(&new_position);
 
         if completed {

--- a/yaobow/shared/src/scripting/sce/commands/role_turn_face.rs
+++ b/yaobow/shared/src/scripting/sce/commands/role_turn_face.rs
@@ -30,7 +30,7 @@ impl SceCommand for SceCommandRoleTurnFace {
 }
 
 impl SceCommandRoleTurnFace {
-    pub fn new(role_id: i32, degree: f32) -> Self {
-        Self { role_id, degree }
+    pub fn new(role_id: i32, degree: i32) -> Self {
+        Self { role_id, degree: degree as f32 }
     }
 }

--- a/yaobow/shared/src/scripting/sce/vm.rs
+++ b/yaobow/shared/src/scripting/sce/vm.rs
@@ -361,7 +361,7 @@ impl SceProcContext {
             }
             24 => {
                 // RoleTurnFace
-                command!(self, SceCommandRoleTurnFace, role_id: i32, degree: f32)
+                command!(self, SceCommandRoleTurnFace, role_id: i32, degree: i32)
             }
             25 => {
                 // TeamOpen


### PR DESCRIPTION
1. RoleTurnFace 接收的参数应该是 i32，可以得到角度值；f32 的话，会解析成很小的值。

2. RolePathTo 的 run 参数如果是 2，则应该是倒退走（雪见登场中，地震后，雪见后退）。计算一个以人物位置为中心，目标位置对称的点，然后设置成人物 look_at 的点即可。（~另外貌似动画也需要倒放？~ 仔细看原版动画是后撤一大步。目前还是走路动作，所以看着像太空漫步... 动画 ~倒放~ 我还不会...）