### PR TITLE
feat: add DlgFace, then make dialog look better

### DIFF
--- a/yaobow/shared/src/openpal3/ui/dlg_box.rs
+++ b/yaobow/shared/src/openpal3/ui/dlg_box.rs
@@ -7,50 +7,62 @@ use radiance::rendering::Sprite;
 use crate::openpal3::asset_manager::AssetManager;
 
 pub struct DialogBox {
-    top_left: Sprite,
-    bottom_left: Sprite,
-    bottom_right: Sprite,
-    top_right: Sprite,
-    left: Sprite,
-    bottom: Sprite,
-    right: Sprite,
-    top: Sprite,
-    background: Sprite,
+    dialog_pic: Vec<Sprite>,
+    click_indicator_pic: Vec<Sprite>,
+    click_indicator_interval: f32,
+    asset_mgr: Rc<AssetManager>,
+    avator: Option<Sprite>,
+    avator_at_right: bool,
 }
 
 impl DialogBox {
     const DLG_HEIGHT_FACTOR: f32 = 0.25;
     const DLG_Y_POSITION_FACTOR: f32 = 1. - Self::DLG_HEIGHT_FACTOR;
+    const DLG_AVATOR_WIDTH_FACTOR: f32 = 1. / 3.;
+    const DLG_CLICK_INDICATOR_PADDING_FACTOR: f32 = 1.4;
+
+    // hard code for decoration at bottom-center
+    const DLG_DECORATION_WIDTH_TRIM: f32 = 66.;
+    const DLG_DECORATION_HEIGHT_TRIM: f32 = 32.;
+    const DLG_DECORATION_BOTTOM_OVER_DIALOG: f32 = 6.;
 
     pub fn new(asset_mgr: Rc<AssetManager>) -> Self {
-        let top_left = Self::load_sprite("/basedata/basedata/ui/flex/dlg0.tga", asset_mgr.as_ref());
-        let bottom_left =
-            Self::load_sprite("/basedata/basedata/ui/flex/dlg1.tga", asset_mgr.as_ref());
-        let bottom_right =
-            Self::load_sprite("/basedata/basedata/ui/flex/dlg2.tga", asset_mgr.as_ref());
-        let top_right =
-            Self::load_sprite("/basedata/basedata/ui/flex/dlg3.tga", asset_mgr.as_ref());
-        let left = Self::load_sprite("/basedata/basedata/ui/flex/dlg4.tga", asset_mgr.as_ref());
-        let bottom = Self::load_sprite("/basedata/basedata/ui/flex/dlg5.tga", asset_mgr.as_ref());
-        let right = Self::load_sprite("/basedata/basedata/ui/flex/dlg6.tga", asset_mgr.as_ref());
-        let top = Self::load_sprite("/basedata/basedata/ui/flex/dlg7.tga", asset_mgr.as_ref());
-        let background =
-            Self::load_sprite("/basedata/basedata/ui/flex/dlg8.tga", asset_mgr.as_ref());
+        // dialog box resources
+        let mut dialog_pic = Vec::new();
+        for i in 0..9 {
+            dialog_pic.push(Self::load_sprite(&format!("/basedata/basedata/ui/flex/dlg{}.tga", i), asset_mgr.as_ref()));
+        }
+        // a small decoration at bottom-center
+        dialog_pic.push(Self::load_sprite("/basedata/basedata/ui/scene/timeclose.tga", asset_mgr.as_ref()));
+
+        // click indicator at bottom-right of the dialog box
+        let mut click_indicator_pic = Vec::new();
+        for i in 0..2 {
+            click_indicator_pic.push(Self::load_sprite(&format!("/basedata/basedata/ui/scene/page{}.tga", i), asset_mgr.as_ref()),)
+        }
 
         Self {
-            top_left,
-            bottom_left,
-            bottom_right,
-            top_right,
-            left,
-            bottom,
-            right,
-            top,
-            background,
+            dialog_pic,
+            click_indicator_pic,
+            click_indicator_interval: 0.0,
+            asset_mgr: asset_mgr.clone(),
+            avator: None,
+            avator_at_right: false,
         }
     }
 
-    pub fn draw(&mut self, text: &str, ui: &Ui, _delta_sec: f32) {
+    pub fn set_avator(&mut self, face_name: &str, left_or_right: i32) {
+        let role_id = face_name[..3].to_string();
+        let path = format!("/basedata/basedata/ROLE/{}/{}.tga", role_id, face_name);
+        self.avator = Some(Self::load_sprite(&path, self.asset_mgr.as_ref()));
+        self.avator_at_right = left_or_right == 1;
+    }
+
+    pub fn clear_avator(&mut self) {
+        self.avator = None;
+    }
+
+    pub fn draw(&mut self, text: &str, ui: &Ui, delta_sec: f32) {
         let [window_width, window_height] = ui.io().display_size;
         let (dialog_x, dialog_width) = {
             if window_width / window_height > 4. / 3. {
@@ -63,7 +75,18 @@ impl DialogBox {
         };
 
         let dialog_height = window_height * Self::DLG_HEIGHT_FACTOR;
-        let dialog_y = window_height * Self::DLG_Y_POSITION_FACTOR;
+        let dialog_y = window_height * Self::DLG_Y_POSITION_FACTOR - Self::DLG_DECORATION_BOTTOM_OVER_DIALOG;
+        let avator_width = window_height * Self::DLG_AVATOR_WIDTH_FACTOR;
+        let click_indicator_right_offset = if self.avator_at_right && self.avator.is_some() {
+            // avator has set and avator is at right side
+            avator_width
+        } else {
+            0.
+        };
+
+        // FIXME: seem not a good method to get font size
+        let font = ui.fonts().fonts()[1];
+        let font_size = ui.fonts().get_font(font).unwrap().font_size;
 
         ui.window("dlg_box")
             .collapsible(false)
@@ -75,96 +98,196 @@ impl DialogBox {
             .position([dialog_x, dialog_y], Condition::Appearing)
             .build(|| {
                 let top_left_inner = (
-                    dialog_x + self.top_left.width() as f32,
-                    dialog_y + self.top_left.height() as f32,
+                    dialog_x + self.dialog_pic[0].width() as f32,
+                    dialog_y + self.dialog_pic[0].height() as f32,
                 );
 
                 let bottom_left_inner = (
-                    dialog_x + self.bottom_left.width() as f32,
-                    dialog_y + dialog_height - self.bottom_left.height() as f32,
+                    dialog_x + self.dialog_pic[1].width() as f32,
+                    dialog_y + dialog_height - self.dialog_pic[1].height() as f32,
                 );
 
                 let bottom_right_inner = (
-                    dialog_x + dialog_width - self.bottom_right.width() as f32,
-                    dialog_y + dialog_height - self.bottom_right.height() as f32,
+                    dialog_x + dialog_width - self.dialog_pic[2].width() as f32,
+                    dialog_y + dialog_height - self.dialog_pic[2].height() as f32,
                 );
 
                 let top_right_inner = (
-                    dialog_x + dialog_width - self.top_right.width() as f32,
-                    dialog_y + self.top_right.height() as f32,
+                    dialog_x + dialog_width - self.dialog_pic[3].width() as f32,
+                    dialog_y + self.dialog_pic[3].height() as f32,
                 );
+
+                let decoration_min = (
+                    dialog_x + dialog_width / 2.0 - Self::DLG_DECORATION_WIDTH_TRIM,
+                    window_height - Self::DLG_DECORATION_HEIGHT_TRIM
+                );
+
+                let click_indicator_min = [
+                    dialog_x + dialog_width - self.click_indicator_pic[0].width() as f32 * Self::DLG_CLICK_INDICATOR_PADDING_FACTOR - click_indicator_right_offset,
+                    dialog_y + dialog_height - self.click_indicator_pic[0].height() as f32 * Self::DLG_CLICK_INDICATOR_PADDING_FACTOR
+                ];
 
                 let list = ui.get_background_draw_list();
 
+                // top-left
                 list.add_image(
-                    self.top_left.imgui_texture_id(),
+                    self.dialog_pic[0].imgui_texture_id(),
                     [dialog_x, dialog_y],
                     [top_left_inner.0, top_left_inner.1],
                 )
                 .build();
 
+                // bottom-left
                 list.add_image(
-                    self.bottom_left.imgui_texture_id(),
+                    self.dialog_pic[1].imgui_texture_id(),
                     [dialog_x, bottom_left_inner.1],
                     [bottom_left_inner.0, dialog_y + dialog_height],
                 )
                 .build();
 
+                // bottom-right
                 list.add_image(
-                    self.bottom_right.imgui_texture_id(),
+                    self.dialog_pic[2].imgui_texture_id(),
                     [bottom_right_inner.0, bottom_right_inner.1],
                     [dialog_x + dialog_width, dialog_y + dialog_height],
                 )
                 .build();
 
+                // top-right
                 list.add_image(
-                    self.top_right.imgui_texture_id(),
+                    self.dialog_pic[3].imgui_texture_id(),
                     [top_right_inner.0, dialog_y],
                     [dialog_x + dialog_width, top_right_inner.1],
                 )
                 .build();
 
+                // left
                 list.add_image(
-                    self.left.imgui_texture_id(),
+                    self.dialog_pic[4].imgui_texture_id(),
                     [dialog_x, top_left_inner.1],
-                    [dialog_x + self.left.width() as f32, bottom_left_inner.1],
+                    [dialog_x + self.dialog_pic[4].width() as f32, bottom_left_inner.1],
                 )
                 .build();
 
+                // bottom
                 list.add_image(
-                    self.bottom.imgui_texture_id(),
+                    self.dialog_pic[5].imgui_texture_id(),
                     [
                         bottom_left_inner.0,
-                        dialog_y + dialog_height - self.bottom.height() as f32,
+                        dialog_y + dialog_height - self.dialog_pic[5].height() as f32,
                     ],
                     [bottom_right_inner.0, dialog_y + dialog_height],
                 )
                 .build();
 
+                // right
                 list.add_image(
-                    self.right.imgui_texture_id(),
+                    self.dialog_pic[6].imgui_texture_id(),
                     [
-                        dialog_x + dialog_width - self.right.width() as f32,
+                        dialog_x + dialog_width - self.dialog_pic[6].width() as f32,
                         top_right_inner.1,
                     ],
                     [dialog_x + dialog_width, bottom_right_inner.1],
                 )
                 .build();
 
+                // top
                 list.add_image(
-                    self.top.imgui_texture_id(),
+                    self.dialog_pic[7].imgui_texture_id(),
                     [top_left_inner.0, dialog_y],
-                    [top_right_inner.0, dialog_y + self.top.height() as f32],
+                    [top_right_inner.0, dialog_y + self.dialog_pic[7].height() as f32],
                 )
                 .build();
 
+                // center
                 list.add_image(
-                    self.background.imgui_texture_id(),
+                    self.dialog_pic[8].imgui_texture_id(),
                     [top_left_inner.0, top_left_inner.1],
                     [bottom_right_inner.0, bottom_right_inner.1],
                 )
                 .build();
-                ui.text_wrapped(text);
+
+                // decoration at bottom-center
+                list.add_image(
+                    self.dialog_pic[9].imgui_texture_id(),
+                    [decoration_min.0, decoration_min.1],
+                    [decoration_min.0 + self.dialog_pic[9].width() as f32, decoration_min.1 + self.dialog_pic[9].height() as f32]
+                )
+                .build();
+
+                // avator
+                if let Some(avator) = &self.avator {
+                    let avator_height = avator_width / avator.width() as f32 * avator.height() as f32;
+                    let (min, max) = if !self.avator_at_right {
+                        (
+                            [dialog_x + avator_width, window_height - avator_height],
+                            [dialog_x, window_height]
+                        )
+                    } else {
+                        (
+                            [dialog_x + dialog_width - avator_width, window_height - avator_height],
+                            [dialog_x + dialog_width, window_height]
+                        )
+                    };
+                    list.add_image(
+                        avator.imgui_texture_id(),
+                        min,
+                        max
+                    )
+                    .build();
+                }
+
+                // draw click indicator
+                self.click_indicator_interval += delta_sec;
+                if self.click_indicator_interval > 1.0 {
+                    self.click_indicator_interval = 0.0;
+                }
+                list.add_image(
+                    if self.click_indicator_interval > 0.5 {
+                        self.click_indicator_pic[0].imgui_texture_id()
+                    } else {
+                        self.click_indicator_pic[1].imgui_texture_id()
+                    },
+                    [click_indicator_min[0], click_indicator_min[1]],
+                    [click_indicator_min[0] + self.click_indicator_pic[0].width() as f32, click_indicator_min[1] + self.click_indicator_pic[0].width() as f32]
+                ).build();
+
+                // draw text
+                let mut text_x = 0.;
+                let mut text_y = 0.;
+                let mut text_color = imgui::ImColor32::WHITE;
+                for c in text.chars() {
+                    if dialog_width - avator_width * 2. - text_x < 0. {
+                        text_y += font_size * 1.5;
+                        text_x = 0.;
+                    }
+                    match c {
+                        '\n' => {
+                            if text_x == 0. {
+                                // already at the beginning, don't change to a new line
+                                continue;
+                            }
+                            text_y += font_size * 1.5;
+                            text_x = 0.;
+                            continue;
+                        }
+                        '\\' => {
+                            continue;
+                        }
+                        'i' => {
+                            // set color to YELLOW
+                            text_color = imgui::ImColor32::from_rgb(0xff, 0xff, 0x00);
+                        }
+                        'r' => {
+                            // set color to default
+                            text_color = imgui::ImColor32::WHITE;
+                        }
+                        _ => {
+                            list.add_text([dialog_x + avator_width + text_x, dialog_y + 18. + text_y], text_color ,&c.to_string());
+                            text_x += font_size * 1.1;
+                        }
+                    }
+                }
             });
     }
 

--- a/yaobow/shared/src/scripting/sce/commands/dlg.rs
+++ b/yaobow/shared/src/scripting/sce/commands/dlg.rs
@@ -25,6 +25,8 @@ impl SceCommand for SceCommandDlg {
     ) -> bool {
         if self.dlg_end {
             // state.global_state_mut().set_adv_input_enabled(self.adv_input_enabled);
+            state.dialog_box().clear_avator();
+
             return true;
         }
 

--- a/yaobow/shared/src/scripting/sce/commands/dlg_face.rs
+++ b/yaobow/shared/src/scripting/sce/commands/dlg_face.rs
@@ -1,0 +1,37 @@
+use crate::scripting::sce::{SceCommand, SceState};
+use crosscom::ComRc;
+use imgui::Ui;
+use radiance::comdef::ISceneManager;
+
+#[derive(Debug, Clone)]
+pub struct SceCommandDlgFace {
+    _id: i32,
+    face_name: String,
+    left_or_right: i32,
+}
+
+impl SceCommand for SceCommandDlgFace {
+    fn initialize(&mut self, _scene_manager: ComRc<ISceneManager>, _state: &mut SceState) {}
+
+    fn update(
+        &mut self,
+        _scene_manager: ComRc<ISceneManager>,
+        _ui: &Ui,
+        state: &mut SceState,
+        _delta_sec: f32,
+    ) -> bool {
+        state.dialog_box().set_avator(&self.face_name, self.left_or_right);
+
+        true
+    }
+}
+
+impl SceCommandDlgFace {
+    pub fn new(_id: i32, face_name: String, left_or_right: i32) -> Self {
+        Self {
+            _id,
+            face_name,
+            left_or_right,
+        }
+    }
+}

--- a/yaobow/shared/src/scripting/sce/commands/mod.rs
+++ b/yaobow/shared/src/scripting/sce/commands/mod.rs
@@ -9,6 +9,7 @@ mod cmp;
 mod dlg;
 mod dlg_sel;
 mod dlg_time;
+mod dlg_face;
 mod entry_row;
 mod fop;
 mod get_appr;
@@ -64,6 +65,7 @@ pub use cmp::{
 pub use dlg::SceCommandDlg;
 pub use dlg_sel::SceCommandDlgSel;
 pub use dlg_time::SceCommandDlgTime;
+pub use dlg_face::SceCommandDlgFace;
 pub use entry_row::SceCommandEntryRow;
 pub use fop::SceCommandFop;
 pub use get_appr::SceCommandGetAppr;

--- a/yaobow/shared/src/scripting/sce/vm.rs
+++ b/yaobow/shared/src/scripting/sce/vm.rs
@@ -498,7 +498,7 @@ impl SceProcContext {
             }
             67 => {
                 // DlgFace
-                nop_command!(self, DlgFace, i32, string, i32)
+                command!(self, SceCommandDlgFace, id: i32, face_name: string, left_or_right: i32)
             }
             68 => {
                 // Note


### PR DESCRIPTION
1. 实现了DlgFace命令，用于设置人物立绘；
2. 修改了 dlg_box 的图片资源存放数据结构为 Vec；
3. dialog 底部有个小的装饰，按照原版找了一个差不多的，但是不确定是不是这个资源；
4. 小装饰的资源存在大量的透明区域，所以代码里为它增加了一些硬编码 ( const DLG_DECORATION_* )；
5. 实现了右下角用于指示可以点击的，闪烁的小图标 (不知如何命名，代码里叫 click indicator )；

PS: 新增功能和修正没有分开 commit （懒，Sorry）