### PR TITLE
fix already borrowed error

### DIFF
--- a/radiance/radiance/src/scene/entity.rs
+++ b/radiance/radiance/src/scene/entity.rs
@@ -121,7 +121,8 @@ impl IEntityImpl for CoreEntity {
             e.update(delta_sec);
         }
 
-        for c in self.components.borrow().values().clone() {
+        let components = self.components.borrow().clone();
+        for c in components.values() {
             c.on_updating(delta_sec);
         }
     }


### PR DESCRIPTION
Crash message:
  panicked at 'already borrowed: BorrowMutError', radiance\radiance\src\scene\entity.rs:73:33

The @components will borrow_mut() during iterating under borrow(), which causes the crash.  Clone it before iterating to fix this crash.

Fixes: 34684ef ("Improve scene perf")