### PR TITLE
fix: don't draw curtain when player starts to control

### DIFF
--- a/yaobow/shared/src/openpal3/directors/adv_director.rs
+++ b/yaobow/shared/src/openpal3/directors/adv_director.rs
@@ -122,6 +122,8 @@ impl AdventureDirector {
             sce_vm_options,
         );
 
+        // don't draw curtain when loading a save
+        sce_vm.state_mut().set_curtain(0.);
         sce_vm.state_mut().try_call_proc_by_name(&format!(
             "_{}_{}",
             scene_name.as_ref().unwrap(),

--- a/yaobow/shared/src/scripting/sce/commands/role_input.rs
+++ b/yaobow/shared/src/scripting/sce/commands/role_input.rs
@@ -19,6 +19,11 @@ impl SceCommand for SceCommandRoleInput {
         state
             .global_state_mut()
             .set_adv_input_enabled(self.enable_input != 0);
+
+        // don't draw curtain when enable player's input
+        if self.enable_input != 0 {
+            state.set_curtain(0.);
+        }
         true
     }
 }


### PR DESCRIPTION
curtain is for fading in/out, it is kept after fading out.  But usually, player starts to control after fading out.  So, set curtain to 0 to not draw curtain.  So is loading a save.

Fixes: e492b29 ("fix: fade out should keep until fade in (#39)")